### PR TITLE
Check external links

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,9 @@ jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
+    with:
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"
   look-for-outdated-code:
     runs-on: ubuntu-22.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Support for migrating the navigation table to the contents index
+- Checks that external references on the contents index return a 2XX response to
+  HEAD requests
 
 ## [v0.7.0] - 2023-10-09
 

--- a/src-docs/__init__.py.md
+++ b/src-docs/__init__.py.md
@@ -51,7 +51,7 @@ Upload the documentation to charmhub.
 
 ---
 
-<a href="../src/__init__.py#L162"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/__init__.py#L170"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run_migrate`
 
@@ -76,7 +76,7 @@ Migrate existing docs from charmhub to local repository.
 
 ---
 
-<a href="../src/__init__.py#L218"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/__init__.py#L226"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pre_flight_checks`
 

--- a/src-docs/__init__.py.md
+++ b/src-docs/__init__.py.md
@@ -16,7 +16,7 @@ Library for uploading docs to charmhub.
 
 ---
 
-<a href="../src/__init__.py#L33"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/__init__.py#L75"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run_reconcile`
 
@@ -45,13 +45,13 @@ Upload the documentation to charmhub.
 
 **Raises:**
  
- - <b>`InputError`</b>:  if there are any problems with executing any of the actions. 
+ - <b>`InputError`</b>:  if there are any problems with the contents index or executing any of the  actions. 
  - <b>`TaggingNotAllowedError`</b>:  if the reconcile tries to tag a branch which is not the main base  branch 
 
 
 ---
 
-<a href="../src/__init__.py#L170"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/__init__.py#L195"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run_migrate`
 
@@ -76,7 +76,7 @@ Migrate existing docs from charmhub to local repository.
 
 ---
 
-<a href="../src/__init__.py#L226"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/__init__.py#L251"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pre_flight_checks`
 

--- a/src-docs/check.py.md
+++ b/src-docs/check.py.md
@@ -11,7 +11,7 @@ Module for running checks.
 
 ---
 
-<a href="../src/check.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/check.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_path_with_diffs`
 
@@ -37,7 +37,7 @@ Generate the paths that have either local or server content changes.
 
 ---
 
-<a href="../src/check.py#L162"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/check.py#L161"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `conflicts`
 
@@ -71,7 +71,7 @@ The second type of conflict is a logical conflict which arises out of that there
 
 ---
 
-<a href="../src/check.py#L274"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/check.py#L273"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `external_refs`
 

--- a/src-docs/check.py.md
+++ b/src-docs/check.py.md
@@ -11,7 +11,7 @@ Module for running checks.
 
 ---
 
-<a href="../src/check.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/check.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_path_with_diffs`
 
@@ -37,7 +37,7 @@ Generate the paths that have either local or server content changes.
 
 ---
 
-<a href="../src/check.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/check.py#L162"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `conflicts`
 
@@ -67,6 +67,35 @@ The second type of conflict is a logical conflict which arises out of that there
 
 **Yields:**
  A problem for each action with a conflict 
+
+
+---
+
+<a href="../src/check.py#L277"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `external_refs`
+
+```python
+external_refs(
+    table_rows: Iterable[TableRow],
+    discourse: Discourse
+) → Iterator[Problem]
+```
+
+Check whether external references are valid. 
+
+This check sends a HEAD requests and checks for a 2XX response after any redirects. 
+
+
+
+**Args:**
+ 
+ - <b>`table_rows`</b>:  The table rows to check. 
+
+
+
+**Yields:**
+ A problem for each table row with an invalid external reference. 
 
 
 ---

--- a/src-docs/check.py.md
+++ b/src-docs/check.py.md
@@ -71,14 +71,13 @@ The second type of conflict is a logical conflict which arises out of that there
 
 ---
 
-<a href="../src/check.py#L277"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/check.py#L274"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `external_refs`
 
 ```python
 external_refs(
-    table_rows: Iterable[TableRow],
-    discourse: Discourse
+    index_contents: Iterable[IndexContentsListItem]
 ) → Iterator[Problem]
 ```
 
@@ -90,12 +89,12 @@ This check sends a HEAD requests and checks for a 2XX response after any redirec
 
 **Args:**
  
- - <b>`table_rows`</b>:  The table rows to check. 
+ - <b>`index_contents`</b>:  The contents list items to check. 
 
 
 
 **Yields:**
- A problem for each table row with an invalid external reference. 
+ A problem for each list item with an invalid external reference. 
 
 
 ---

--- a/src-docs/types_.py.md
+++ b/src-docs/types_.py.md
@@ -165,6 +165,23 @@ Attrs:  hierarchy: The number of parent items to the root of the list  reference
 
 ---
 
+#### <kbd>property</kbd> is_external
+
+Whether the row is an external reference. 
+
+
+
+**Args:**
+ 
+ - <b>`server_hostname`</b>:  The hostname of the discourse server. 
+
+
+
+**Returns:**
+ Whether the item in the table is an external item. 
+
+---
+
 #### <kbd>property</kbd> table_path
 
 The table path for the item. 

--- a/src-docs/types_.py.md
+++ b/src-docs/types_.py.md
@@ -171,14 +171,8 @@ Whether the row is an external reference.
 
 
 
-**Args:**
- 
- - <b>`server_hostname`</b>:  The hostname of the discourse server. 
-
-
-
 **Returns:**
- Whether the item in the table is an external item. 
+  Whether the item in the table is an external item. 
 
 ---
 

--- a/src-docs/types_.py.md
+++ b/src-docs/types_.py.md
@@ -160,7 +160,7 @@ Attrs:  old: The previous content.  new: The new content.
 ## <kbd>class</kbd> `IndexContentsListItem`
 Represents an item in the contents table. 
 
-Attrs:  hierarchy: The number of parent items to the root of the list  reference_title: The name of the reference  reference_value: The link to the referenced item  rank: The number of preceding elements in the list at any hierarchy  hidden: Whether the item should be displayed on the navigation table  table_path: The path for the item on the table. 
+Attrs:  hierarchy: The number of parent items to the root of the list  reference_title: The name of the reference  reference_value: The link to the referenced item  rank: The number of preceding elements in the list at any hierarchy  hidden: Whether the item should be displayed on the navigation table  table_path: The path for the item on the table.  is_external: Whether the item is an external reference. 
 
 
 ---

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,6 +3,7 @@
 
 """Library for uploading docs to charmhub."""
 import logging
+from collections.abc import Iterable, Iterator
 from itertools import tee
 
 from src import action, check, docs_directory
@@ -17,9 +18,12 @@ from src.exceptions import InputError, TaggingNotAllowedError
 from src.repository import DEFAULT_BRANCH_NAME
 from src.types_ import (
     ActionResult,
+    AnyAction,
+    Index,
     MigrateOutputs,
     PullRequestAction,
     ReconcileOutputs,
+    TableRow,
     Url,
     UserInputs,
 )
@@ -28,6 +32,44 @@ GETTING_STARTED = (
     "To get started with discourse-gatekeeper, "
     "please refer to https://github.com/canonical/discourse-gatekeeper#getting-started"
 )
+
+
+def _get_reconcile_actions(
+    index: Index, table_rows: Iterable[TableRow], clients: Clients
+) -> Iterator[AnyAction]:
+    """Upload the documentation to charmhub.
+
+    Args:
+        index: Information about the index of the documentation.
+        table_rows: The rows of the navigation table.
+        clients: The clients to interact with things like discourse and the repository.
+
+    Returns:
+        The reconcile actions to execute.
+
+    Raises:
+        InputError: if there are any problems with the contents index.
+    """
+    docs_path = clients.repository.base_path / DOCUMENTATION_FOLDER_NAME
+    path_infos = docs_directory.read(docs_path=docs_path)
+
+    index_contents = index_module.get_contents(index_file=index.local, docs_path=docs_path)
+    index_contents, check_index_contents = tee(index_contents, 2)
+    problems = tuple(check.external_refs(index_contents=check_index_contents))
+    if problems:
+        raise InputError(
+            "One or more of the contents index entries are not valid, see the log for details"
+        )
+
+    sorted_path_infos = sort_module.using_contents_index(
+        path_infos=path_infos, index_contents=index_contents, docs_path=docs_path
+    )
+    return reconcile.run(
+        sorted_path_infos=sorted_path_infos,
+        table_rows=table_rows,
+        clients=clients,
+        base_path=clients.repository.base_path,
+    )
 
 
 def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs | None:
@@ -41,7 +83,8 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
         ReconcileOutputs object with the result of the action. None, if there is no reconcile.
 
     Raises:
-        InputError: if there are any problems with executing any of the actions.
+        InputError: if there are any problems with the contents index or executing any of the
+            actions.
         TaggingNotAllowedError: if the reconcile tries to tag a branch which is not the main base
             branch
     """
@@ -65,30 +108,12 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
         base_path=clients.repository.base_path,
         server_client=clients.discourse,
     )
-    docs_path = clients.repository.base_path / DOCUMENTATION_FOLDER_NAME
-    path_infos = docs_directory.read(docs_path=docs_path)
     server_content = (
         index.server.content if index.server is not None and index.server.content else ""
     )
-
-    index_contents = index_module.get_contents(index_file=index.local, docs_path=docs_path)
-    index_contents, check_index_contents = tee(index_contents, 2)
-    problems = tuple(check.external_refs(index_contents=check_index_contents))
-    if problems:
-        raise InputError(
-            "One or more of the contents index entries are not valid, see the log for details"
-        )
-
-    sorted_path_infos = sort_module.using_contents_index(
-        path_infos=path_infos, index_contents=index_contents, docs_path=docs_path
-    )
-    table_rows = list(navigation_table.from_page(page=server_content, discourse=clients.discourse))
-    actions = reconcile.run(
-        sorted_path_infos=sorted_path_infos,
-        table_rows=table_rows,
-        clients=clients,
-        base_path=clients.repository.base_path,
-    )
+    table_rows = navigation_table.from_page(page=server_content, discourse=clients.discourse)
+    table_rows, action_table_rows = tee(table_rows, 2)
+    actions = _get_reconcile_actions(index=index, table_rows=action_table_rows, clients=clients)
 
     # tee creates a copy of the iterator which is needed as check.conflicts consumes the iterator
     # it is passed

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -70,7 +70,15 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
     server_content = (
         index.server.content if index.server is not None and index.server.content else ""
     )
+
     index_contents = index_module.get_contents(index_file=index.local, docs_path=docs_path)
+    index_contents, check_index_contents = tee(index_contents, 2)
+    problems = tuple(check.external_refs(index_contents=check_index_contents))
+    if problems:
+        raise InputError(
+            "One or more of the contents index entries are not valid, see the log for details"
+        )
+
     sorted_path_infos = sort_module.using_contents_index(
         path_infos=path_infos, index_contents=index_contents, docs_path=docs_path
     )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -37,7 +37,7 @@ GETTING_STARTED = (
 def _get_reconcile_actions(
     index: Index, table_rows: Iterable[TableRow], clients: Clients
 ) -> Iterator[AnyAction]:
-    """Upload the documentation to charmhub.
+    """Get the actions to be executed for reconciliation.
 
     Args:
         index: Information about the index of the documentation.

--- a/src/check.py
+++ b/src/check.py
@@ -285,8 +285,7 @@ def external_refs(index_contents: Iterable[IndexContentsListItem]) -> Iterator[P
         list_item for list_item in index_contents if list_item.is_external
     )
 
-    for problem in filter(
+    yield from filter(
         None,
         (_external_ref_list_item_problem(list_item) for list_item in external_ref_index_contents),
-    ):
-        yield problem
+    )

--- a/src/check.py
+++ b/src/check.py
@@ -261,7 +261,7 @@ def _external_ref_list_item_problem(list_item: IndexContentsListItem) -> Problem
             "there is a problem with a row on the contents index\n"
             "path: %s\n"
             "problem: %s\n"
-            "table row: %s"
+            "list item: %s"
         ),
         problem.path,
         problem.description,

--- a/src/types_.py
+++ b/src/types_.py
@@ -565,6 +565,18 @@ class IndexContentsListItem(typing.NamedTuple):
     hidden: bool
 
     @property
+    def is_external(self) -> bool:
+        """Whether the row is an external reference.
+
+        Args:
+            server_hostname: The hostname of the discourse server.
+
+        Returns:
+            Whether the item in the table is an external item.
+        """
+        return self.reference_value.lower().startswith("http")
+
+    @property
     def table_path(self) -> TablePath:
         """The table path for the item.
 
@@ -576,7 +588,7 @@ class IndexContentsListItem(typing.NamedTuple):
         Returns:
             The table path for the item.
         """
-        if self.reference_value.lower().startswith("http"):
+        if self.is_external:
             transformed_reference_value = (
                 self.reference_value.replace("//", "/")
                 .replace(".", "/")

--- a/src/types_.py
+++ b/src/types_.py
@@ -569,9 +569,6 @@ class IndexContentsListItem(typing.NamedTuple):
     def is_external(self) -> bool:
         """Whether the row is an external reference.
 
-        Args:
-            server_hostname: The hostname of the discourse server.
-
         Returns:
             Whether the item in the table is an external item.
         """

--- a/src/types_.py
+++ b/src/types_.py
@@ -556,6 +556,7 @@ class IndexContentsListItem(typing.NamedTuple):
         rank: The number of preceding elements in the list at any hierarchy
         hidden: Whether the item should be displayed on the navigation table
         table_path: The path for the item on the table.
+        is_external: Whether the item is an external reference.
     """
 
     hierarchy: int

--- a/tests/integration/test___init__run_migrate.py
+++ b/tests/integration/test___init__run_migrate.py
@@ -85,16 +85,16 @@ Testing index page content.
 
 | Level | Path | Navlink |
 | -- | -- | -- |
-| 1 | https-canonical-com-1 | [Canonical 1](https://canonical.com/1) |
+| 1 | https-canonical-com-1 | [Canonical 1](https://canonical.com/blog) |
 | 1 | group-1 | [Group 1]() |
 | 1 | group-2 | [Group 2]() |
 | 2 | group-2-content-1 | [{content_page_1.content}]({content_page_1_url}) |
 | 2 | group-2-content-2 | [{content_page_2.content}]({content_page_2_url}) |
-| 2 | https-canonical-com-2 | [Canonical 2](https://canonical.com/2) |
+| 2 | https-canonical-com-2 | [Canonical 2](https://canonical.com/press-centre) |
 | 1 | group-3 | [Group 3]() |
 | 2 | group-3-group-4 | [Group 4]() |
 | 3 | group-3-group-4-content-3 | [{content_page_3.content}]({content_page_3_url}) |
-| 3 | https-canonical-com-3 | [Canonical 3](https://canonical.com/3) |
+| 3 | https-canonical-com-3 | [Canonical 3](https://canonical.com/projects) |
 | 2 | group-3-content-4 | [{content_page_4.content}]({content_page_4_url}) |
 | 1 | group-5 | [Group 5]() |"""
     index_url = discourse_api.create_topic(
@@ -140,16 +140,16 @@ Testing index page content.
 
 # Contents
 
-1. [Canonical 1](https://canonical.com/1)
+1. [Canonical 1](https://canonical.com/blog)
 1. [Group 1](group-1)
 1. [Group 2](group-2)
   1. [{content_page_1.content}](group-2/content-1.md)
   1. [{content_page_2.content}](group-2/content-2.md)
-  1. [Canonical 2](https://canonical.com/2)
+  1. [Canonical 2](https://canonical.com/press-centre)
 1. [Group 3](group-3)
   1. [Group 4](group-3/group-4)
     1. [{content_page_3.content}](group-3/group-4/content-3.md)
-    1. [Canonical 3](https://canonical.com/3)
+    1. [Canonical 3](https://canonical.com/projects)
   1. [{content_page_4.content}](group-3/content-4.md)
 1. [Group 5](group-5)"""
     )

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -403,7 +403,7 @@ def test__run_reconcile_invalid_external_item(mocked_clients):
     with mocked_clients.repository.with_branch(DEFAULT_BRANCH) as repo:
         (docs_dir := repo.base_path / "docs").mkdir()
         (docs_dir / "index.md").write_text(
-            f"""index content
+            """index content
 # contents
 - [Page 1](https://invalid.link.com')
 """,

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -391,6 +391,40 @@ def test__run_reconcile_hidden_item(mocked_clients):
     "src.repository.Client.metadata",
     types_.Metadata(name="name 1", docs=None),
 )
+def test__run_reconcile_invalid_external_item(mocked_clients):
+    """
+    arrange: given metadata with name but not docs and docs folder with an external item on the
+        index that points to a broken link
+    act: when _run_reconcile is called
+    assert: then InputError is raised.
+    """
+    mocked_clients.discourse.create_topic.side_effect = ["url 1"]
+
+    with mocked_clients.repository.with_branch(DEFAULT_BRANCH) as repo:
+        (docs_dir := repo.base_path / "docs").mkdir()
+        (docs_dir / "index.md").write_text(
+            f"""index content
+# contents
+- [Page 1](https://invalid.link.com')
+""",
+            encoding="utf-8",
+        )
+        repo.update_branch("new commit")
+
+        user_inputs = factories.UserInputsFactory(
+            dry_run=False, delete_pages=True, commit_sha=repo.current_commit
+        )
+
+        with pytest.raises(exceptions.InputError) as exc_info:
+            run_reconcile(clients=mocked_clients, user_inputs=user_inputs)
+
+        assert_substrings_in_string(("contents", "index", "not", "valid"), str(exc_info.value))
+
+
+@mock.patch(
+    "src.repository.Client.metadata",
+    types_.Metadata(name="name 1", docs=None),
+)
 def test__run_reconcile_external_item(mocked_clients):
     """
     arrange: given metadata with name but not docs and docs folder with an external item on the

--- a/tests/unit/test_check.py
+++ b/tests/unit/test_check.py
@@ -428,18 +428,14 @@ def _test_external_refs_parameters():
     return [
         pytest.param((), (), id="empty"),
         pytest.param(
-            (
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(link="https://canonical.com")
-                ),
-            ),
+            (factories.IndexContentsListItemFactory(reference_value="https://canonical.com"),),
             (),
             id="single valid link",
         ),
         pytest.param(
             (
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(link=(path_1 := "https://invalid.link.com"))
+                factories.IndexContentsListItemFactory(
+                    reference_value=(path_1 := "https://invalid.link.com")
                 ),
             ),
             (
@@ -452,10 +448,8 @@ def _test_external_refs_parameters():
         ),
         pytest.param(
             (
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(
-                        link=(path_1 := "https://canonica.com/invalid-page")
-                    )
+                factories.IndexContentsListItemFactory(
+                    reference_value=(path_1 := "https://canonica.com/invalid-page")
                 ),
             ),
             (
@@ -468,14 +462,10 @@ def _test_external_refs_parameters():
         ),
         pytest.param(
             (
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(
-                        link=(path_1 := "https://canonica.com/invalid-page-1")
-                    )
+                factories.IndexContentsListItemFactory(
+                    reference_value=(path_1 := "https://canonica.com/invalid-page-1")
                 ),
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(link="https://canonical.com")
-                ),
+                factories.IndexContentsListItemFactory(reference_value="https://canonical.com"),
             ),
             (
                 ExpectedProblem(
@@ -487,13 +477,9 @@ def _test_external_refs_parameters():
         ),
         pytest.param(
             (
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(link="https://canonical.com")
-                ),
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(
-                        link=(path_2 := "https://canonica.com/invalid-page-2")
-                    )
+                factories.IndexContentsListItemFactory(reference_value="https://canonical.com"),
+                factories.IndexContentsListItemFactory(
+                    reference_value=(path_2 := "https://canonica.com/invalid-page-2")
                 ),
             ),
             (
@@ -506,13 +492,11 @@ def _test_external_refs_parameters():
         ),
         pytest.param(
             (
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(link=(path_1 := "https://invalid.url.com"))
+                factories.IndexContentsListItemFactory(
+                    reference_value=(path_1 := "https://invalid.url.com")
                 ),
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(
-                        link=(path_2 := "https://canonica.com/invalid-page-2")
-                    )
+                factories.IndexContentsListItemFactory(
+                    reference_value=(path_2 := "https://canonica.com/invalid-page-2")
                 ),
             ),
             (
@@ -529,11 +513,9 @@ def _test_external_refs_parameters():
         ),
         pytest.param(
             (
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(link="https://canonical.com")
-                ),
-                factories.TableRowFactory(
-                    navlink=factories.NavlinkFactory(link="https://canonical.com/blog")
+                factories.IndexContentsListItemFactory(reference_value="https://canonical.com"),
+                factories.IndexContentsListItemFactory(
+                    reference_value="https://canonical.com/blog"
                 ),
             ),
             (),
@@ -543,25 +525,22 @@ def _test_external_refs_parameters():
 
 
 @pytest.mark.parametrize(
-    "table_rows, expected_problems",
+    "index_contents, expected_problems",
     _test_external_refs_parameters(),
 )
 def test_external_refs(
-    table_rows: tuple[types_.TableRow, ...],
+    index_contents: tuple[types_.IndexContentsListItem, ...],
     expected_problems: tuple[ExpectedProblem],
     caplog: pytest.LogCaptureFixture,
-    mocked_clients,
 ):
     """
-    arrange: given table_rows
-    act: when external_refs is called with the table rows
+    arrange: given index_contents
+    act: when external_refs is called with the list items
     assert: then the expected problems are yielded.
     """
     caplog.set_level(logging.INFO)
 
-    returned_problems = tuple(
-        check.external_refs(table_rows=table_rows, discourse=mocked_clients.discourse)
-    )
+    returned_problems = tuple(check.external_refs(index_contents=index_contents))
 
     assert len(returned_problems) == len(expected_problems)
     for returned_problem, expected_problem in zip(returned_problems, expected_problems):
@@ -572,7 +551,8 @@ def test_external_refs(
         assert_substrings_in_string(
             (
                 "problem",
-                "table",
+                "contents",
+                "index",
                 "row",
                 returned_problem.path,
                 returned_problem.description,

--- a/tests/unit/test_check.py
+++ b/tests/unit/test_check.py
@@ -441,7 +441,7 @@ def _test_external_refs_parameters():
             (
                 ExpectedProblem(
                     path=path_1,
-                    description_contents=("unable", "connect", "ConnectionError"),
+                    description_contents=("unable", "connect", "exception"),
                 ),
             ),
             id="single invalid link connection error",
@@ -502,7 +502,7 @@ def _test_external_refs_parameters():
             (
                 ExpectedProblem(
                     path=path_1,
-                    description_contents=("unable", "connect", "ConnectionError"),
+                    description_contents=("unable", "connect", "exception"),
                 ),
                 ExpectedProblem(
                     path=path_2,

--- a/tests/unit/test_check.py
+++ b/tests/unit/test_check.py
@@ -417,3 +417,165 @@ def test_conflicts(
             ),
             caplog.text,
         )
+
+
+def _test_external_refs_parameters():
+    """Generate parameters for the test_external_refs test.
+
+    Returns:
+        The tests.
+    """
+    return [
+        pytest.param((), (), id="empty"),
+        pytest.param(
+            (
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(link="https://canonical.com")
+                ),
+            ),
+            (),
+            id="single valid link",
+        ),
+        pytest.param(
+            (
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(link=(path_1 := "https://invalid.link.com"))
+                ),
+            ),
+            (
+                ExpectedProblem(
+                    path=path_1,
+                    description_contents=("unable", "connect", "ConnectionError"),
+                ),
+            ),
+            id="single invalid link connection error",
+        ),
+        pytest.param(
+            (
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(
+                        link=(path_1 := "https://canonica.com/invalid-page")
+                    )
+                ),
+            ),
+            (
+                ExpectedProblem(
+                    path=path_1,
+                    description_contents=("broken", "link", "404"),
+                ),
+            ),
+            id="single invalid link 404",
+        ),
+        pytest.param(
+            (
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(
+                        link=(path_1 := "https://canonica.com/invalid-page-1")
+                    )
+                ),
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(link="https://canonical.com")
+                ),
+            ),
+            (
+                ExpectedProblem(
+                    path=path_1,
+                    description_contents=("broken", "link", "404"),
+                ),
+            ),
+            id="multiple first invalid",
+        ),
+        pytest.param(
+            (
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(link="https://canonical.com")
+                ),
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(
+                        link=(path_2 := "https://canonica.com/invalid-page-2")
+                    )
+                ),
+            ),
+            (
+                ExpectedProblem(
+                    path=path_2,
+                    description_contents=("broken", "link", "404"),
+                ),
+            ),
+            id="multiple second invalid",
+        ),
+        pytest.param(
+            (
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(link=(path_1 := "https://invalid.url.com"))
+                ),
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(
+                        link=(path_2 := "https://canonica.com/invalid-page-2")
+                    )
+                ),
+            ),
+            (
+                ExpectedProblem(
+                    path=path_1,
+                    description_contents=("unable", "connect", "ConnectionError"),
+                ),
+                ExpectedProblem(
+                    path=path_2,
+                    description_contents=("broken", "link", "404"),
+                ),
+            ),
+            id="multiple invalid",
+        ),
+        pytest.param(
+            (
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(link="https://canonical.com")
+                ),
+                factories.TableRowFactory(
+                    navlink=factories.NavlinkFactory(link="https://canonical.com/blog")
+                ),
+            ),
+            (),
+            id="multiple valid links",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "table_rows, expected_problems",
+    _test_external_refs_parameters(),
+)
+def test_external_refs(
+    table_rows: tuple[types_.TableRow, ...],
+    expected_problems: tuple[ExpectedProblem],
+    caplog: pytest.LogCaptureFixture,
+    mocked_clients,
+):
+    """
+    arrange: given table_rows
+    act: when external_refs is called with the table rows
+    assert: then the expected problems are yielded.
+    """
+    caplog.set_level(logging.INFO)
+
+    returned_problems = tuple(
+        check.external_refs(table_rows=table_rows, discourse=mocked_clients.discourse)
+    )
+
+    assert len(returned_problems) == len(expected_problems)
+    for returned_problem, expected_problem in zip(returned_problems, expected_problems):
+        assert returned_problem.path == expected_problem.path
+        assert_substrings_in_string(
+            expected_problem.description_contents, returned_problem.description
+        )
+        assert_substrings_in_string(
+            (
+                "problem",
+                "table",
+                "row",
+                returned_problem.path,
+                returned_problem.description,
+            ),
+            caplog.text,
+        )


### PR DESCRIPTION
Applicable spec: https://discourse.charmhub.io/t/specification-isd003-upload-charm-docs-contents-index-and-navigation-table/7986

### Overview

Checks that external references on the contents index point to a resource that returns a 2XX response

### Rationale

Ensures that no broken links make it into the navigation table.

### Module Changes

Introduces a new function into the check module to check external links

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Changelog has been updated
- [ ] Version has been incremented

version will be updated on release
