### PR TITLE
Add a formatted representation of the UpdatePageAction dataclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Added a formatted representation of the UpdatePageAction dataclass for more
+  human-readable output.
+
 ## [v0.8.0] - 2023-11-30
 
 ### Added

--- a/src/types_.py
+++ b/src/types_.py
@@ -389,7 +389,7 @@ class UpdatePageAction(_UpdateActionBase):
 
     content_change: ContentChange
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a formatted representation of the dataclass.
 
         Returns:

--- a/src/types_.py
+++ b/src/types_.py
@@ -396,7 +396,7 @@ class UpdatePageAction(_UpdateActionBase):
             Formatted representation of the dataclass.
         """
         return (
-            f"level: {self.level}, path: {self.path}, "
+            f"class: {self.__class__}, level: {self.level}, path: {self.path}, "
             f"navlink_change: {self.navlink_change}\n"
             f"content_change:\n{self.content_change}"
         )

--- a/src/types_.py
+++ b/src/types_.py
@@ -389,6 +389,12 @@ class UpdatePageAction(_UpdateActionBase):
 
     content_change: ContentChange
 
+    def __str__(self):
+        """Return a formatted representation of the dataclass."""
+        return (f"level: {self.level}, path: {self.path}, "
+                f"navlink_change: {self.navlink_change}\n"
+                f"content_change:\n{self.content_change}")
+
 
 @dataclasses.dataclass
 class UpdateExternalRefAction(_UpdateActionBase):

--- a/src/types_.py
+++ b/src/types_.py
@@ -390,7 +390,11 @@ class UpdatePageAction(_UpdateActionBase):
     content_change: ContentChange
 
     def __str__(self):
-        """Return a formatted representation of the dataclass."""
+        """Return a formatted representation of the dataclass.
+
+        Returns:
+            Formatted representation of the dataclass.
+        """
         return (f"level: {self.level}, path: {self.path}, "
                 f"navlink_change: {self.navlink_change}\n"
                 f"content_change:\n{self.content_change}")

--- a/src/types_.py
+++ b/src/types_.py
@@ -395,9 +395,11 @@ class UpdatePageAction(_UpdateActionBase):
         Returns:
             Formatted representation of the dataclass.
         """
-        return (f"level: {self.level}, path: {self.path}, "
-                f"navlink_change: {self.navlink_change}\n"
-                f"content_change:\n{self.content_change}")
+        return (
+            f"level: {self.level}, path: {self.path}, "
+            f"navlink_change: {self.navlink_change}\n"
+            f"content_change:\n{self.content_change}"
+        )
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Add a formatted representation of the UpdatePageAction dataclass.

### Rationale

This relates to https://github.com/canonical/discourse-gatekeeper/issues/226. I've started by only adding for one dataclass to get some feedback on the approach before I apply it more widely.

### Module Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Changelog has been updated
- [ ] Version has been incremented

Haven't incremented the version as I'm not sure if that's appropriate.
