### PR TITLE
Prepare discourse-gatekeeper for PAAS app charmer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added a formatted representation of the UpdatePageAction dataclass for more
   human-readable output.
-- If metadata.yaml does not exist, is reads name and doc information from
+- If metadata.yaml does not exist, read the name and doc information from the
   charmcraft.yaml file.
 - New input environment variable INPUT_CHARM_DIR. metadata.yaml or charmcraft.yaml
   will be read from this directory instead of the base one and the documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## [Unreleased]
+## [v0.8.3] - 2024-03-26
 
 - Added a formatted representation of the UpdatePageAction dataclass for more
   human-readable output.
+- If metadata.yaml does not exist, is reads name and doc information from
+  charmcraft.yaml file.
+- New input environment variable INPUT_CHARM_DIR. metadata.yaml or charmcraft.yaml
+  will be read from this directory instead of the base one and the documentation
+  will also be searched under this directory.
 
 ## [v0.8.2] - 2024-02-16
 

--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,14 @@ inputs:
       variable GITHUB_SHA.
     required: false
     type: string
+  charm_dir:
+    description: |
+      Relative name of the directory where the metadata.yaml or charmcraft.yaml files are located
+      if they are not in the root directory of the repository. The docs directory is also located
+      under this directory.
+    default: ''
+    required: false
+    type: string
 outputs:
   index_url:
     description: |

--- a/main.py
+++ b/main.py
@@ -168,9 +168,11 @@ def execute_in_tmpdir(func: typing.Callable[..., T]) -> typing.Callable[..., T]:
                 logging.info("execute_in_tmpdir, execute_cwd cwd %s", execute_cwd)
                 shutil.copytree(src=initial_cwd, dst=execute_cwd)
                 os.chdir(execute_cwd)
-                logging.info("execute_in_tmpdir, after listdir %s", os.listdir())
+                logging.info("execute_in_tmpdir, after listdir cwd %s", os.listdir())
+                logging.info("execute_in_tmpdir, after listdir execute_cwd %s", os.listdir(execute_cwd))
                 output = func(execute_cwd, *args, **kwargs)
         finally:
+            logging.info("execute_in_tmpdir back to %s", initial_cwd)
             os.chdir(initial_cwd)
 
         return output

--- a/main.py
+++ b/main.py
@@ -159,12 +159,16 @@ def execute_in_tmpdir(func: typing.Callable[..., T]) -> typing.Callable[..., T]:
             output of the wrapped external function
         """
         initial_cwd = Path.cwd()
+        logging.info("execute_in_tmpdir, Initial cwd %s", initial_cwd)
+        logging.info("execute_in_tmpdir, listdir %s", os.listdir())
         try:
             with tempfile.TemporaryDirectory() as tempdir_name:
                 tempdir = Path(tempdir_name)
                 execute_cwd = tempdir / "cwd"
+                logging.info("execute_in_tmpdir, execute_cwd cwd %s", execute_cwd)
                 shutil.copytree(src=initial_cwd, dst=execute_cwd)
                 os.chdir(execute_cwd)
+                logging.info("execute_in_tmpdir, after listdir %s", os.listdir())
                 output = func(execute_cwd, *args, **kwargs)
         finally:
             os.chdir(initial_cwd)

--- a/main.py
+++ b/main.py
@@ -161,22 +161,14 @@ def execute_in_tmpdir(func: typing.Callable[..., T]) -> typing.Callable[..., T]:
             output of the wrapped external function
         """
         initial_cwd = Path.cwd()
-        logging.info("execute_in_tmpdir, Initial cwd %s", initial_cwd)
-        logging.info("execute_in_tmpdir, listdir %s", os.listdir())
         try:
             with tempfile.TemporaryDirectory() as tempdir_name:
                 tempdir = Path(tempdir_name)
                 execute_cwd = tempdir / "cwd"
-                logging.info("execute_in_tmpdir, execute_cwd cwd %s", execute_cwd)
                 shutil.copytree(src=initial_cwd, dst=execute_cwd)
                 os.chdir(execute_cwd)
-                logging.info("execute_in_tmpdir, after listdir cwd %s", os.listdir())
-                logging.info(
-                    "execute_in_tmpdir, after listdir execute_cwd %s", os.listdir(execute_cwd)
-                )
                 output = func(execute_cwd, *args, **kwargs)
         finally:
-            logging.info("execute_in_tmpdir back to %s", initial_cwd)
             os.chdir(initial_cwd)
 
         return output

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ def _parse_env_vars() -> types_.UserInputs:
     github_access_token = os.getenv("INPUT_GITHUB_TOKEN")
     base_branch = os.getenv("INPUT_BASE_BRANCH", DEFAULT_BRANCH)
     commit_sha = os.getenv("INPUT_COMMIT_SHA")
+    charm_dir = os.getenv("INPUT_CHARM_DIR", "")
 
     event_path = os.getenv("GITHUB_EVENT_PATH")
     if not event_path:
@@ -79,6 +80,7 @@ def _parse_env_vars() -> types_.UserInputs:
         github_access_token=github_access_token,
         commit_sha=commit_sha,
         base_branch=base_branch,
+        charm_dir=charm_dir,
     )
 
 
@@ -169,7 +171,9 @@ def execute_in_tmpdir(func: typing.Callable[..., T]) -> typing.Callable[..., T]:
                 shutil.copytree(src=initial_cwd, dst=execute_cwd)
                 os.chdir(execute_cwd)
                 logging.info("execute_in_tmpdir, after listdir cwd %s", os.listdir())
-                logging.info("execute_in_tmpdir, after listdir execute_cwd %s", os.listdir(execute_cwd))
+                logging.info(
+                    "execute_in_tmpdir, after listdir execute_cwd %s", os.listdir(execute_cwd)
+                )
                 output = func(execute_cwd, *args, **kwargs)
         finally:
             logging.info("execute_in_tmpdir back to %s", initial_cwd)

--- a/src-docs/__init__.py.md
+++ b/src-docs/__init__.py.md
@@ -9,7 +9,6 @@ Library for uploading docs to charmhub.
 ---------------
 - **DRY_RUN_NAVLINK_LINK**
 - **FAIL_NAVLINK_LINK**
-- **DOCUMENTATION_FOLDER_NAME**
 - **DOCUMENTATION_TAG**
 - **DEFAULT_BRANCH_NAME**
 - **GETTING_STARTED**

--- a/src-docs/docs_directory.py.md
+++ b/src-docs/docs_directory.py.md
@@ -8,7 +8,6 @@ Class for reading the docs directory.
 **Global Variables**
 ---------------
 - **DOC_FILE_EXTENSION**
-- **DOCUMENTATION_FOLDER_NAME**
 
 ---
 
@@ -67,7 +66,7 @@ Algorithm:  1.  Get a list of all sub directories and .md files in the docs fold
 ## <kbd>function</kbd> `has_docs_directory`
 
 ```python
-has_docs_directory(base_path: Path) → bool
+has_docs_directory(docs_path: Path) → bool
 ```
 
 Return existence of docs directory from base path. 
@@ -76,7 +75,7 @@ Return existence of docs directory from base path.
 
 **Args:**
  
- - <b>`base_path`</b>:  Base path of the repository to search the docs directory from 
+ - <b>`docs_path`</b>:  Docs path of the repository where docs are 
 
 
 

--- a/src-docs/download.py.md
+++ b/src-docs/download.py.md
@@ -5,13 +5,10 @@
 # <kbd>module</kbd> `download.py`
 Library for downloading docs folder from charmhub. 
 
-**Global Variables**
----------------
-- **DOCUMENTATION_FOLDER_NAME**
 
 ---
 
-<a href="../src/download.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/download.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `recreate_docs`
 

--- a/src-docs/index.py.md
+++ b/src-docs/index.py.md
@@ -8,7 +8,6 @@ Execute the uploading of documentation.
 **Global Variables**
 ---------------
 - **DOC_FILE_EXTENSION**
-- **DOCUMENTATION_FOLDER_NAME**
 - **DOCUMENTATION_INDEX_FILENAME**
 - **NAVIGATION_HEADING**
 - **CONTENTS_HEADER**
@@ -16,12 +15,12 @@ Execute the uploading of documentation.
 
 ---
 
-<a href="../src/index.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/index.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get`
 
 ```python
-get(metadata: Metadata, base_path: Path, server_client: Discourse) → Index
+get(metadata: Metadata, docs_path: Path, server_client: Discourse) → Index
 ```
 
 Retrieve the local and server index information. 
@@ -31,7 +30,7 @@ Retrieve the local and server index information.
 **Args:**
  
  - <b>`metadata`</b>:  Information about the charm. 
- - <b>`base_path`</b>:  The base path to look for the metadata file in. 
+ - <b>`docs_path`</b>:  The base path to look for the documentation. 
  - <b>`server_client`</b>:  A client to the documentation server. 
 
 
@@ -48,7 +47,7 @@ Retrieve the local and server index information.
 
 ---
 
-<a href="../src/index.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/index.py#L85"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `contents_from_page`
 
@@ -72,7 +71,7 @@ Get index file contents from server page.
 
 ---
 
-<a href="../src/index.py#L205"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/index.py#L200"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_content_for_server`
 
@@ -96,7 +95,7 @@ Get the contents from the index file that should be passed to the server.
 
 ---
 
-<a href="../src/index.py#L262"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/index.py#L257"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `classify_item_reference`
 
@@ -124,7 +123,7 @@ Classify the type of a reference.
 
 ---
 
-<a href="../src/index.py#L414"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/index.py#L409"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_contents`
 

--- a/src-docs/metadata.py.md
+++ b/src-docs/metadata.py.md
@@ -7,13 +7,17 @@ Module for parsing metadata.yaml file.
 
 **Global Variables**
 ---------------
+- **CHARMCRAFT_FILENAME**
+- **CHARMCRAFT_NAME_KEY**
+- **CHARMCRAFT_LINKS_KEY**
+- **CHARMCRAFT_LINKS_DOCS_KEY**
 - **METADATA_DOCS_KEY**
 - **METADATA_FILENAME**
 - **METADATA_NAME_KEY**
 
 ---
 
-<a href="../src/metadata.py#L18"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/metadata.py#L22"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get`
 
@@ -23,11 +27,13 @@ get(path: Path) → Metadata
 
 Check for and read the metadata. 
 
+The charm metadata can be in the file metadata.yaml or in charmcraft.yaml. From charmcraft version 2.5, the information should be in charmcraft.yaml, and the user should only modify that file. This function does not consider the case in which the name is in one file and the doc link is in the other. 
+
 
 
 **Args:**
  
- - <b>`path`</b>:  The base path to look for the metadata file in. 
+ - <b>`path`</b>:  The base path to look for the metadata files. 
 
 
 
@@ -38,6 +44,6 @@ Check for and read the metadata.
 
 **Raises:**
  
- - <b>`InputError`</b>:  if the metadata file does not exists or is malformed. 
+ - <b>`InputError`</b>:  if the metadata file does not exist or is malformed. 
 
 

--- a/src-docs/repository.py.md
+++ b/src-docs/repository.py.md
@@ -25,12 +25,16 @@ Module for handling interactions with git repository.
 
 ---
 
-<a href="../src/repository.py#L722"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L748"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_repository_client`
 
 ```python
-create_repository_client(access_token: str | None, base_path: Path) → Client
+create_repository_client(
+    access_token: str | None,
+    base_path: Path,
+    charm_dir: str = ''
+) → Client
 ```
 
 Create a Github instance to handle communication with Github server. 
@@ -41,6 +45,7 @@ Create a Github instance to handle communication with Github server.
  
  - <b>`access_token`</b>:  Access token that has permissions to open a pull request. 
  - <b>`base_path`</b>:  Path where local .git resides in. 
+ - <b>`charm_dir`</b>:  Relative directory where the charm files are located. 
 
 
 
@@ -59,14 +64,18 @@ Create a Github instance to handle communication with Github server.
 ## <kbd>class</kbd> `Client`
 Wrapper for git/git-server related functionalities. 
 
-Attrs:  base_path: The root directory of the repository.  metadata: Metadata object of the charm  has_docs_directory: whether the repository has a docs directory  current_branch: current git branch used in the repository  current_commit: current commit checkout in the repository  branches: list of all branches 
+Attrs:  base_path: The root directory of the repository.  base_charm_path: The directory of the repository where the charm is.  docs_path: The directory of the repository where the documentation is.  metadata: Metadata object of the charm  has_docs_directory: whether the repository has a docs directory  current_branch: current git branch used in the repository  current_commit: current commit checkout in the repository  branches: list of all branches 
 
-<a href="../src/repository.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L180"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(repository: Repo, github_repository: Repository) → None
+__init__(
+    repository: Repo,
+    github_repository: Repository,
+    charm_dir: str = ''
+) → None
 ```
 
 Construct. 
@@ -77,7 +86,19 @@ Construct.
  
  - <b>`repository`</b>:  Client for interacting with local git repository. 
  - <b>`github_repository`</b>:  Client for interacting with remote github repository. 
+ - <b>`charm_dir`</b>:  Relative directory where charm files are located. 
 
+
+---
+
+#### <kbd>property</kbd> base_charm_path
+
+Return the Path of the charm in the repository. 
+
+
+
+**Returns:**
+  Path of the repository. 
 
 ---
 
@@ -99,6 +120,17 @@ Return the current branch.
 
 ---
 
+#### <kbd>property</kbd> docs_path
+
+Return the Path of the charm in the repository. 
+
+
+
+**Returns:**
+  Path of the repository. 
+
+---
+
 #### <kbd>property</kbd> has_docs_directory
 
 Return whether the repository has a docs directory. 
@@ -113,7 +145,7 @@ Return the Metadata object of the charm.
 
 ---
 
-<a href="../src/repository.py#L358"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L383"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `create_branch`
 
@@ -147,7 +179,7 @@ repository.create_branch(branch_name).switch(branch_name)
 
 ---
 
-<a href="../src/repository.py#L520"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L546"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `create_pull_request`
 
@@ -176,7 +208,7 @@ Create pull request for changes in given repository path.
 
 ---
 
-<a href="../src/repository.py#L616"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L642"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_file_content_from_tag`
 
@@ -208,7 +240,7 @@ Get the content of a file for a specific tag.
 
 ---
 
-<a href="../src/repository.py#L494"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L520"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_pull_request`
 
@@ -237,12 +269,12 @@ Return open pull request matching the provided branch name.
 
 ---
 
-<a href="../src/repository.py#L251"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L275"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_summary`
 
 ```python
-get_summary(directory: str | None = 'docs') → DiffSummary
+get_summary(directory: str | Path | None) → DiffSummary
 ```
 
 Return a summary of the differences against the most recent commit. 
@@ -260,7 +292,7 @@ Return a summary of the differences against the most recent commit.
 
 ---
 
-<a href="../src/repository.py#L267"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L292"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_commit_in_branch`
 
@@ -290,7 +322,7 @@ Check if commit exists in a given branch.
 
 ---
 
-<a href="../src/repository.py#L562"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L588"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_dirty`
 
@@ -313,7 +345,7 @@ Check if repository path has any changes including new files.
 
 ---
 
-<a href="../src/repository.py#L479"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L505"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_same_commit`
 
@@ -337,7 +369,7 @@ Return whether tag and commit coincides.
 
 ---
 
-<a href="../src/repository.py#L298"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L323"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `pull`
 
@@ -355,7 +387,7 @@ Pull content from remote for the provided branch.
 
 ---
 
-<a href="../src/repository.py#L310"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L335"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `switch`
 
@@ -378,7 +410,7 @@ Switch branch for the repository.
 
 ---
 
-<a href="../src/repository.py#L592"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L618"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `tag_commit`
 
@@ -403,7 +435,7 @@ Tag a commit, if the tag already exists, it is deleted first.
 
 ---
 
-<a href="../src/repository.py#L577"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L603"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `tag_exists`
 
@@ -426,16 +458,16 @@ Check if a given tag exists.
 
 ---
 
-<a href="../src/repository.py#L404"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L429"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_branch`
 
 ```python
 update_branch(
     commit_msg: str,
+    directory: str | Path | None,
     push: bool = True,
-    force: bool = False,
-    directory: str | None = 'docs'
+    force: bool = False
 ) → Client
 ```
 
@@ -463,7 +495,7 @@ Update branch with a new commit.
 
 ---
 
-<a href="../src/repository.py#L548"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repository.py#L574"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_pull_request`
 
@@ -481,7 +513,7 @@ Update and push changes to the given branch.
 
 ---
 
-<a href="../repository/py/with_branch#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../repository/py/with_branch#L256"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `with_branch`
 

--- a/src-docs/types_.py.md
+++ b/src-docs/types_.py.md
@@ -371,7 +371,7 @@ Whether the row is a group of pages.
 
 ---
 
-<a href="../src/types_.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/types_.py#L174"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_external`
 
@@ -394,7 +394,7 @@ Whether the row is an external reference.
 
 ---
 
-<a href="../src/types_.py#L188"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/types_.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `to_markdown`
 
@@ -461,7 +461,7 @@ Attrs:  content_change: The change to the documentation content.
 ## <kbd>class</kbd> `UserInputs`
 Configurable user input values used to run discourse-gatekeeper. 
 
-Attrs:  discourse: The configuration for interacting with discourse.  dry_run: If enabled, only log the action that would be taken. Has no effect in migration  mode.  delete_pages: Whether to delete pages that are no longer needed. Has no effect in  migration mode.  github_access_token: A Personal Access Token(PAT) or access token with repository access.  Required in migration mode.  commit_sha: The SHA of the commit the action is running on.  base_branch: The main branch against which the syncs act on 
+Attrs:  discourse: The configuration for interacting with discourse.  dry_run: If enabled, only log the action that would be taken. Has no effect in migration  mode.  delete_pages: Whether to delete pages that are no longer needed. Has no effect in  migration mode.  github_access_token: A Personal Access Token(PAT) or access token with repository access.  Required in migration mode.  commit_sha: The SHA of the commit the action is running on.  base_branch: The main branch against which the syncs act on.  charm_dir: Directory the charm is located in. 
 
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,7 +12,7 @@ from src import navigation_table, reconcile
 from src import sort as sort_module
 from src.action import DRY_RUN_NAVLINK_LINK, FAIL_NAVLINK_LINK
 from src.clients import Clients
-from src.constants import DOCUMENTATION_FOLDER_NAME, DOCUMENTATION_TAG
+from src.constants import DOCUMENTATION_TAG
 from src.download import recreate_docs
 from src.exceptions import InputError, TaggingNotAllowedError
 from src.repository import DEFAULT_BRANCH_NAME
@@ -50,7 +50,7 @@ def _get_reconcile_actions(
     Raises:
         InputError: if there are any problems with the contents index.
     """
-    docs_path = clients.repository.base_charm_path / DOCUMENTATION_FOLDER_NAME
+    docs_path = clients.repository.docs_path
     path_infos = docs_directory.read(docs_path=docs_path)
 
     index_contents = index_module.get_contents(index_file=index.local, docs_path=docs_path)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -105,7 +105,7 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
 
     index = index_module.get(
         metadata=clients.repository.metadata,
-        base_path=clients.repository.base_path,
+        docs_path=clients.repository.docs_path,
         server_client=clients.discourse,
     )
     server_content = (

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -50,7 +50,7 @@ def _get_reconcile_actions(
     Raises:
         InputError: if there are any problems with the contents index.
     """
-    docs_path = clients.repository.base_path / DOCUMENTATION_FOLDER_NAME
+    docs_path = clients.repository.base_charm_path / DOCUMENTATION_FOLDER_NAME
     path_infos = docs_directory.read(docs_path=docs_path)
 
     index_contents = index_module.get_contents(index_file=index.local, docs_path=docs_path)

--- a/src/clients.py
+++ b/src/clients.py
@@ -42,6 +42,8 @@ def get_clients(user_inputs: UserInputs, base_path: Path) -> Clients:
             api_key=user_inputs.discourse.api_key,
         ),
         repository=create_repository_client(
-            access_token=user_inputs.github_access_token, base_path=base_path
+            access_token=user_inputs.github_access_token,
+            base_path=base_path,
+            charm_dir=user_inputs.charm_dir,
         ),
     )

--- a/src/constants.py
+++ b/src/constants.py
@@ -9,7 +9,7 @@ another module or to resolve circular imports.
 DEFAULT_BRANCH = "main"
 DOCUMENTATION_TAG = "discourse-gatekeeper/base-content"
 
-DOCUMENTATION_FOLDER_NAME = "docs"
+DOCUMENTATION_FOLDER_NAME = "charm/docs"
 DOC_FILE_EXTENSION = ".md"
 DOCUMENTATION_INDEX_FILENAME = f"index{DOC_FILE_EXTENSION}"
 NAVIGATION_HEADING = "Navigation"

--- a/src/constants.py
+++ b/src/constants.py
@@ -9,7 +9,7 @@ another module or to resolve circular imports.
 DEFAULT_BRANCH = "main"
 DOCUMENTATION_TAG = "discourse-gatekeeper/base-content"
 
-DOCUMENTATION_FOLDER_NAME = "charm/docs"
+DOCUMENTATION_FOLDER_NAME = "docs"
 DOC_FILE_EXTENSION = ".md"
 DOCUMENTATION_INDEX_FILENAME = f"index{DOC_FILE_EXTENSION}"
 NAVIGATION_HEADING = "Navigation"

--- a/src/docs_directory.py
+++ b/src/docs_directory.py
@@ -9,7 +9,7 @@ from itertools import count
 from pathlib import Path
 
 from src import types_
-from src.constants import DOC_FILE_EXTENSION, DOCUMENTATION_FOLDER_NAME
+from src.constants import DOC_FILE_EXTENSION
 
 
 def _get_directories_files(docs_path: Path) -> list[Path]:
@@ -152,13 +152,13 @@ def read(docs_path: Path) -> typing.Iterator[types_.PathInfo]:
     )
 
 
-def has_docs_directory(base_path: Path) -> bool:
+def has_docs_directory(docs_path: Path) -> bool:
     """Return existence of docs directory from base path.
 
     Args:
-        base_path: Base path of the repository to search the docs directory from
+        docs_path: Docs path of the repository where docs are
 
     Returns:
         True if documentation folder exists, False otherwise
     """
-    return (base_path / DOCUMENTATION_FOLDER_NAME).is_dir()
+    return docs_path.is_dir()

--- a/src/download.py
+++ b/src/download.py
@@ -1,4 +1,3 @@
-
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/download.py
+++ b/src/download.py
@@ -1,3 +1,4 @@
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
@@ -19,7 +20,7 @@ def _download_from_discourse(clients: Clients) -> None:
     Args:
         clients: Clients object
     """
-    base_path = clients.repository.base_path
+    base_path = clients.repository.base_charm_path
     metadata = clients.repository.metadata
 
     index = get_index(metadata=metadata, base_path=base_path, server_client=clients.discourse)
@@ -49,7 +50,7 @@ def recreate_docs(clients: Clients, base: str) -> bool:
     clients.repository.switch(base)
 
     # Remove docs folder and recreate content from discourse
-    docs_path = clients.repository.base_path / DOCUMENTATION_FOLDER_NAME
+    docs_path = clients.repository.base_charm_path / DOCUMENTATION_FOLDER_NAME
 
     if docs_path.exists():
         shutil.rmtree(docs_path)

--- a/src/download.py
+++ b/src/download.py
@@ -18,7 +18,6 @@ def _download_from_discourse(clients: Clients) -> None:
     Args:
         clients: Clients object
     """
-    charm_path = clients.repository.base_charm_path
     docs_path = clients.repository.docs_path
     metadata = clients.repository.metadata
 

--- a/src/download.py
+++ b/src/download.py
@@ -6,7 +6,6 @@
 import shutil
 
 from src.clients import Clients
-from src.constants import DOCUMENTATION_FOLDER_NAME
 from src.index import contents_from_page
 from src.index import get as get_index
 from src.migration import run as migrate_contents
@@ -19,10 +18,11 @@ def _download_from_discourse(clients: Clients) -> None:
     Args:
         clients: Clients object
     """
-    base_path = clients.repository.base_charm_path
+    charm_path = clients.repository.base_charm_path
+    docs_path = clients.repository.docs_path
     metadata = clients.repository.metadata
 
-    index = get_index(metadata=metadata, base_path=base_path, server_client=clients.discourse)
+    index = get_index(metadata=metadata, base_path=charm_path, server_client=clients.discourse)
     server_content = (
         index.server.content if index.server is not None and index.server.content else ""
     )
@@ -32,7 +32,7 @@ def _download_from_discourse(clients: Clients) -> None:
         table_rows=table_rows,
         index_content=index_content,
         discourse=clients.discourse,
-        docs_path=base_path / DOCUMENTATION_FOLDER_NAME,
+        docs_path=docs_path,
     )
 
 
@@ -49,7 +49,7 @@ def recreate_docs(clients: Clients, base: str) -> bool:
     clients.repository.switch(base)
 
     # Remove docs folder and recreate content from discourse
-    docs_path = clients.repository.base_charm_path / DOCUMENTATION_FOLDER_NAME
+    docs_path = clients.repository.docs_path
 
     if docs_path.exists():
         shutil.rmtree(docs_path)

--- a/src/download.py
+++ b/src/download.py
@@ -22,7 +22,7 @@ def _download_from_discourse(clients: Clients) -> None:
     docs_path = clients.repository.docs_path
     metadata = clients.repository.metadata
 
-    index = get_index(metadata=metadata, base_path=charm_path, server_client=clients.discourse)
+    index = get_index(metadata=metadata, docs_path=docs_path, server_client=clients.discourse)
     server_content = (
         index.server.content if index.server is not None and index.server.content else ""
     )

--- a/src/index.py
+++ b/src/index.py
@@ -34,30 +34,30 @@ _HIDDEN_ITEM = _ITEM.replace(r"^", r"^<!-- ").replace(r"$", r" -->$")
 _HIDDEN_ITEM_PATTERN = re.compile(_HIDDEN_ITEM)
 
 
-def _read_docs_index(base_path: Path) -> str | None:
+def _read_docs_index(docs_path: Path) -> str | None:
     """Read the content of the index file.
 
     Args:
-        base_path: The starting path to look for the index content.
+        docs_path: The path to look for the index content.
 
     Returns:
         The content of the index file if it exists, otherwise return None.
 
     """
-    if not (docs_directory := base_path / DOCUMENTATION_FOLDER_NAME).is_dir():
+    if not docs_path.is_dir():
         return None
-    if not (index_file := docs_directory / DOCUMENTATION_INDEX_FILENAME).is_file():
+    if not (index_file := docs_path / DOCUMENTATION_INDEX_FILENAME).is_file():
         return None
 
     return index_file.read_text()
 
 
-def get(metadata: Metadata, base_path: Path, server_client: Discourse) -> Index:
+def get(metadata: Metadata, docs_path: Path, server_client: Discourse) -> Index:
     """Retrieve the local and server index information.
 
     Args:
         metadata: Information about the charm.
-        base_path: The base path to look for the metadata file in.
+        docs_path: The base path to look for the documentation.
         server_client: A client to the documentation server.
 
     Returns:
@@ -78,7 +78,7 @@ def get(metadata: Metadata, base_path: Path, server_client: Discourse) -> Index:
         server = None
 
     name_value = metadata.name
-    local_content = _read_docs_index(base_path=base_path)
+    local_content = _read_docs_index(docs_path=docs_path)
     local = IndexFile(
         title=f"{name_value.replace('-', ' ').title()} Documentation Overview",
         content=local_content,

--- a/src/index.py
+++ b/src/index.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 from src.constants import (
     DOC_FILE_EXTENSION,
-    DOCUMENTATION_FOLDER_NAME,
     DOCUMENTATION_INDEX_FILENAME,
     NAVIGATION_HEADING,
 )

--- a/src/index.py
+++ b/src/index.py
@@ -10,11 +10,7 @@ from collections.abc import Iterable
 from enum import Enum, auto
 from pathlib import Path
 
-from src.constants import (
-    DOC_FILE_EXTENSION,
-    DOCUMENTATION_INDEX_FILENAME,
-    NAVIGATION_HEADING,
-)
+from src.constants import DOC_FILE_EXTENSION, DOCUMENTATION_INDEX_FILENAME, NAVIGATION_HEADING
 from src.discourse import Discourse
 from src.exceptions import DiscourseError, InputError, ServerError
 from src.types_ import Index, IndexContentsListItem, IndexFile, Metadata, Page

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -3,8 +3,6 @@
 
 """Module for parsing metadata.yaml file."""
 
-import logging
-import os
 from pathlib import Path
 
 import yaml

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -39,13 +39,6 @@ def get(path: Path) -> types_.Metadata:
         InputError: if the metadata file does not exist or are malformed.
 
     """
-    logging.info("metadata.get, path: %s abs path: %s", path, path.absolute())
-    logging.info("metadata.get, cwd %s", os.getcwd())
-    logging.info("metadata.get, list dir cwd %s", os.listdir())
-    logging.info("metadata.get, list dir cwd .. %s", os.listdir(".."))
-    logging.info("metadata.get, list dir sent path. %s", os.listdir(path))
-    logging.info("metadata.get, list dir sent path .. %s", os.listdir(path / ".."))
-
     metadata_yaml = path / METADATA_FILENAME
     if metadata_yaml.is_file():
         return _parse_metadata_yaml(metadata_yaml)

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -34,7 +34,7 @@ def get(path: Path) -> types_.Metadata:
         The contents of the metadata file.
 
     Raises:
-        InputError: if the metadata file does not exist or are malformed.
+        InputError: if the metadata file does not exist or is malformed.
 
     """
     metadata_yaml = path / METADATA_FILENAME

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -4,6 +4,7 @@
 """Module for parsing metadata.yaml file."""
 
 from pathlib import Path
+import os
 import logging
 
 import yaml
@@ -39,6 +40,9 @@ def get(path: Path) -> types_.Metadata:
 
     """
     logging.info("metadata.get, path: %s abs path: %s", path, path.absolute())
+    logging.info("metadata.get, list dir . %s", os.listdir())
+    logging.info("metadata.get, list dir ... %s", os.listdir('..'))
+
 
     metadata_yaml = path / METADATA_FILENAME
     if metadata_yaml.is_file():

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -3,9 +3,9 @@
 
 """Module for parsing metadata.yaml file."""
 
-from pathlib import Path
-import os
 import logging
+import os
+from pathlib import Path
 
 import yaml
 
@@ -42,9 +42,9 @@ def get(path: Path) -> types_.Metadata:
     logging.info("metadata.get, path: %s abs path: %s", path, path.absolute())
     logging.info("metadata.get, cwd %s", os.getcwd())
     logging.info("metadata.get, list dir cwd %s", os.listdir())
-    logging.info("metadata.get, list dir cwd .. %s", os.listdir('..'))
+    logging.info("metadata.get, list dir cwd .. %s", os.listdir(".."))
     logging.info("metadata.get, list dir sent path. %s", os.listdir(path))
-    logging.info("metadata.get, list dir sent path .. %s", os.listdir(path / '..'))
+    logging.info("metadata.get, list dir sent path .. %s", os.listdir(path / ".."))
 
     metadata_yaml = path / METADATA_FILENAME
     if metadata_yaml.is_file():

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -4,6 +4,7 @@
 """Module for parsing metadata.yaml file."""
 
 from pathlib import Path
+import logging
 
 import yaml
 
@@ -37,6 +38,8 @@ def get(path: Path) -> types_.Metadata:
         InputError: if the metadata file does not exist or are malformed.
 
     """
+    logging.info("metadata.get, path: %s abs path: %s", path, path.absolute())
+
     metadata_yaml = path / METADATA_FILENAME
     if metadata_yaml.is_file():
         return _parse_metadata_yaml(metadata_yaml)

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -40,6 +40,7 @@ def get(path: Path) -> types_.Metadata:
 
     """
     logging.info("metadata.get, path: %s abs path: %s", path, path.absolute())
+    logging.info("metadata.get, cwd %s", os.getcwd())
     logging.info("metadata.get, list dir cwd %s", os.listdir())
     logging.info("metadata.get, list dir cwd .. %s", os.listdir('..'))
     logging.info("metadata.get, list dir sent path. %s", os.listdir(path))

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -40,9 +40,10 @@ def get(path: Path) -> types_.Metadata:
 
     """
     logging.info("metadata.get, path: %s abs path: %s", path, path.absolute())
-    logging.info("metadata.get, list dir . %s", os.listdir())
-    logging.info("metadata.get, list dir ... %s", os.listdir('..'))
-
+    logging.info("metadata.get, list dir cwd %s", os.listdir())
+    logging.info("metadata.get, list dir cwd .. %s", os.listdir('..'))
+    logging.info("metadata.get, list dir sent path. %s", os.listdir(path))
+    logging.info("metadata.get, list dir sent path .. %s", os.listdir(path / '..'))
 
     metadata_yaml = path / METADATA_FILENAME
     if metadata_yaml.is_file():

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -10,6 +10,10 @@ import yaml
 from src import types_
 from src.exceptions import InputError
 
+CHARMCRAFT_FILENAME = "charmcraft.yaml"
+CHARMCRAFT_NAME_KEY = "name"
+CHARMCRAFT_LINKS_KEY = "links"
+CHARMCRAFT_LINKS_DOCS_KEY = "documentation"
 METADATA_DOCS_KEY = "docs"
 METADATA_FILENAME = "metadata.yaml"
 METADATA_NAME_KEY = "name"
@@ -18,20 +22,47 @@ METADATA_NAME_KEY = "name"
 def get(path: Path) -> types_.Metadata:
     """Check for and read the metadata.
 
+    The charm metadata can be in the file metadata.yaml or in charmcraft.yaml.
+    From charmcraft version 2.5, the information should be in charmcraft.yaml,
+    and the user should only modify that file. This function does not consider
+    the case in which the name is in one file and the doc link is in the other.
+
     Args:
-        path: The base path to look for the metadata file in.
+        path: The base path to look for the metadata files.
 
     Returns:
         The contents of the metadata file.
 
     Raises:
-        InputError: if the metadata file does not exists or is malformed.
+        InputError: if the metadata file does not exist or are malformed.
 
     """
     metadata_yaml = path / METADATA_FILENAME
-    if not metadata_yaml.is_file():
-        raise InputError(f"Could not find {METADATA_FILENAME} file, looked in folder: {path}")
+    if metadata_yaml.is_file():
+        return _parse_metadata_yaml(metadata_yaml)
 
+    charmcraft_yaml = path / CHARMCRAFT_FILENAME
+    if charmcraft_yaml.is_file():
+        return _parse_charmcraft_yaml(charmcraft_yaml)
+
+    raise InputError(
+        f"Could not find {METADATA_FILENAME} or {CHARMCRAFT_FILENAME} files"
+        f", looked in folder: {path}"
+    )
+
+
+def _parse_metadata_yaml(metadata_yaml: Path) -> types_.Metadata:
+    """Parse metadata file.
+
+    Args:
+        metadata_yaml: The file path the the metadata file.
+
+    Returns:
+        The contents of the metadata file.
+
+    Raises:
+        InputError: if the metadata file does not exist or are malformed.
+    """
     try:
         metadata = yaml.safe_load(metadata_yaml.read_text())
     except yaml.error.YAMLError as exc:
@@ -60,5 +91,57 @@ def get(path: Path) -> types_.Metadata:
         METADATA_DOCS_KEY in metadata and docs is None
     ):
         raise InputError(f"Invalid value for docs key: {docs}, expected a string value")
+
+    return types_.Metadata(name=name, docs=docs)
+
+
+def _parse_charmcraft_yaml(charmcraft_yaml: Path) -> types_.Metadata:
+    """Parse charmcraft file.
+
+    Args:
+        charmcraft_yaml: The file path the the charmcraft file.
+
+    Returns:
+        The contents of the charmcraft file.
+
+    Raises:
+        InputError: if the charmcraft file does not exist or are malformed.
+    """
+    try:
+        charmcraft = yaml.safe_load(charmcraft_yaml.read_text())
+    except yaml.error.YAMLError as exc:
+        raise InputError(
+            f"Malformed {CHARMCRAFT_FILENAME} file, read file: {charmcraft_yaml}"
+        ) from exc
+
+    if not charmcraft:
+        raise InputError(f"{CHARMCRAFT_FILENAME} file is empty, read file: {charmcraft_yaml}")
+    if not isinstance(charmcraft, dict):
+        raise InputError(
+            f"{CHARMCRAFT_FILENAME} file does not contain a mapping at the root, "
+            f"read file: {charmcraft_yaml}, content: {charmcraft!r}"
+        )
+
+    if CHARMCRAFT_NAME_KEY not in charmcraft:
+        raise InputError(
+            f"Could not find required key: {CHARMCRAFT_NAME_KEY}, "
+            f"read file: {charmcraft_yaml}, content: {charmcraft!r}"
+        )
+    if not isinstance(name := charmcraft[CHARMCRAFT_NAME_KEY], str):
+        raise InputError(f"Invalid value for name key: {name}, expected a string value")
+
+    docs = None
+    links = charmcraft.get(CHARMCRAFT_LINKS_KEY)
+    if links:
+        if not isinstance(links, dict):
+            raise InputError(
+                f"{CHARMCRAFT_FILENAME} invalid value for links {CHARMCRAFT_LINKS_KEY} key."
+            )
+
+        docs = links.get(CHARMCRAFT_LINKS_DOCS_KEY)
+        if not (isinstance(docs, str) or docs is None):
+            raise InputError(
+                f"Invalid value for documentation key: {docs}, expected a string value"
+            )
 
     return types_.Metadata(name=name, docs=docs)

--- a/src/repository.py
+++ b/src/repository.py
@@ -193,17 +193,26 @@ class Client:  # pylint: disable=too-many-public-methods
         Returns:
             Path of the repository.
         """
-        return Path(self._git_repo.working_tree_dir or self._git_repo.common_dir) / "charm"
+        return Path(self._git_repo.working_tree_dir or self._git_repo.common_dir)
+
+    @cached_property
+    def base_charm_path(self) -> Path:
+        """Return the Path of the charm in the repository.
+
+        Returns:
+            Path of the repository.
+        """
+        return self.base_path / "charm"
 
     @property
     def metadata(self) -> Metadata:
         """Return the Metadata object of the charm."""
-        return get_metadata(self.base_path)
+        return get_metadata(self.base_charm_path)
 
     @property
     def has_docs_directory(self) -> bool:
         """Return whether the repository has a docs directory."""
-        return has_docs_directory(self.base_path)
+        return has_docs_directory(self.base_charm_path)
 
     @property
     def current_branch(self) -> str:

--- a/src/repository.py
+++ b/src/repository.py
@@ -168,6 +168,7 @@ class Client:  # pylint: disable=too-many-public-methods
 
     Attrs:
         base_path: The root directory of the repository.
+        base_charm_path: The directory of the repository where the charm is.
         metadata: Metadata object of the charm
         has_docs_directory: whether the repository has a docs directory
         current_branch: current git branch used in the repository
@@ -175,15 +176,19 @@ class Client:  # pylint: disable=too-many-public-methods
         branches: list of all branches
     """
 
-    def __init__(self, repository: Repo, github_repository: Repository) -> None:
+    def __init__(
+        self, repository: Repo, github_repository: Repository, charm_dir: str = ""
+    ) -> None:
         """Construct.
 
         Args:
             repository: Client for interacting with local git repository.
             github_repository: Client for interacting with remote github repository.
+            charm_dir: Relative directory where charm files are located.
         """
         self._git_repo = repository
         self._github_repo = github_repository
+        self._charm_dir = charm_dir
         self._configure_git_user()
 
     @cached_property
@@ -202,7 +207,7 @@ class Client:  # pylint: disable=too-many-public-methods
         Returns:
             Path of the repository.
         """
-        return self.base_path / "charm"
+        return self.base_path / self._charm_dir
 
     @property
     def metadata(self) -> Metadata:
@@ -729,12 +734,15 @@ def _get_repository_name_from_git_url(remote_url: str) -> str:
     return matched_repository.group(1)
 
 
-def create_repository_client(access_token: str | None, base_path: Path) -> Client:
+def create_repository_client(
+    access_token: str | None, base_path: Path, charm_dir: str = ""
+) -> Client:
     """Create a Github instance to handle communication with Github server.
 
     Args:
         access_token: Access token that has permissions to open a pull request.
         base_path: Path where local .git resides in.
+        charm_dir: Relative directory where the charm files are located.
 
     Raises:
         InputError: if invalid access token or invalid git remote URL is provided.
@@ -753,4 +761,4 @@ def create_repository_client(access_token: str | None, base_path: Path) -> Clien
     remote_url = local_repo.remote().url
     repository_fullname = _get_repository_name_from_git_url(remote_url=remote_url)
     remote_repo = github_client.get_repo(repository_fullname)
-    return Client(repository=local_repo, github_repository=remote_repo)
+    return Client(repository=local_repo, github_repository=remote_repo, charm_dir=charm_dir)

--- a/src/repository.py
+++ b/src/repository.py
@@ -193,7 +193,7 @@ class Client:  # pylint: disable=too-many-public-methods
         Returns:
             Path of the repository.
         """
-        return Path(self._git_repo.working_tree_dir or self._git_repo.common_dir)
+        return Path(self._git_repo.working_tree_dir or self._git_repo.common_dir) / "charm"
 
     @property
     def metadata(self) -> Metadata:

--- a/src/repository.py
+++ b/src/repository.py
@@ -195,7 +195,7 @@ class Client:  # pylint: disable=too-many-public-methods
         """
         return Path(self._git_repo.working_tree_dir or self._git_repo.common_dir)
 
-    @cached_property
+    @property
     def base_charm_path(self) -> Path:
         """Return the Path of the charm in the repository.
 

--- a/src/repository.py
+++ b/src/repository.py
@@ -415,7 +415,8 @@ class Client:  # pylint: disable=too-many-public-methods
         commit_msg: str,
         push: bool = True,
         force: bool = False,
-        directory: str | None = DOCUMENTATION_FOLDER_NAME,
+        # directory: str | None = DOCUMENTATION_FOLDER_NAME,
+        directory: str | None = None,
     ) -> "Client":
         """Update branch with a new commit.
 

--- a/src/types_.py
+++ b/src/types_.py
@@ -44,7 +44,8 @@ class UserInputs(typing.NamedTuple):
         github_access_token: A Personal Access Token(PAT) or access token with repository access.
             Required in migration mode.
         commit_sha: The SHA of the commit the action is running on.
-        base_branch: The main branch against which the syncs act on
+        base_branch: The main branch against which the syncs act on.
+        charm_dir: Directory the charm is located in.
     """
 
     discourse: UserInputsDiscourse
@@ -53,6 +54,7 @@ class UserInputs(typing.NamedTuple):
     github_access_token: str | None
     commit_sha: str
     base_branch: str
+    charm_dir: str
 
 
 class Metadata(typing.NamedTuple):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -359,6 +359,7 @@ class UserInputsFactory(
     base_branch = DEFAULT_BRANCH
     dry_run = False
     delete_pages = False
+    charm_dir = ""
 
 
 class TableRowFactory(

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Unit tests for uploading docs to charmhub."""
+"""Integration tests for uploading docs to charmhub."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -364,7 +364,6 @@ async def discourse_remove_rate_limits(
     settings = {
         "unique_posts_mins": "0",
         "rate_limit_create_post": "0",
-        "rate_limit_new_user_create_topic": "0",
         "rate_limit_new_user_create_post": "0",
         "max_topics_per_day": "1000",
         "max_edits_per_day": "1000",

--- a/tests/integration/test___init__run_conflict.py
+++ b/tests/integration/test___init__run_conflict.py
@@ -95,7 +95,9 @@ async def test_run_conflict(
     reconcile_output = run_reconcile(
         clients=Clients(discourse=discourse_api, repository=repository_client),
         user_inputs=factories.UserInputsFactory(
-            dry_run=False, delete_pages=True, commit_sha=repository_client.current_commit
+            dry_run=False,
+            delete_pages=True,
+            commit_sha=repository_client.current_commit,
         ),
     )
 
@@ -129,7 +131,8 @@ async def test_run_conflict(
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
         "2. docs with a documentation file updated and discourse updated with conflicting "
-        "content in dry run mode"
+        "content in dry run mode",
+        directory=repository_client.docs_path,
     )
 
     with pytest.raises(exceptions.InputError) as exc_info:
@@ -193,7 +196,8 @@ async def test_run_conflict(
     discourse_api.update_topic(url=doc_url, content=doc_content_4)
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
-        "4. docs with a documentation file and discourse updated to resolve conflict"
+        "4. docs with a documentation file and discourse updated to resolve conflict",
+        directory=repository_client.docs_path,
     )
 
     reconcile_output = run_reconcile(
@@ -222,7 +226,8 @@ async def test_run_conflict(
     doc_file.write_text(doc_content_5 := f"# {doc_title}\ncontent 5", encoding="utf-8")
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
-        "5. docs with an index and documentation and alternate documentation file"
+        "5. docs with an index and documentation and alternate documentation file",
+        directory=repository_client.docs_path,
     )
     mock_content_file.content = b64encode(doc_content_4.encode(encoding="utf-8"))
 
@@ -261,7 +266,8 @@ async def test_run_conflict(
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
         "# 6. docs with an index and changed documentation and alternate documentation with "
-        "server changes"
+        "server changes",
+        directory=repository_client.docs_path,
     )
     mock_content_file.content = b64encode(doc_content_5.encode(encoding="utf-8"))
     mock_alt_content_file = MagicMock(spec=ContentFile)

--- a/tests/integration/test___init__run_migrate.py
+++ b/tests/integration/test___init__run_migrate.py
@@ -29,7 +29,8 @@ pytestmark = pytest.mark.migrate
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("patch_create_repository_client")
+@pytest.mark.usefixtures("git_repo")
+@pytest.mark.parametrize("charm_id, charm_dir", [("1", ""), ("2", "charm")])
 async def test_run_migrate(
     discourse_address: str,
     discourse_api: Discourse,
@@ -40,6 +41,8 @@ async def test_run_migrate(
     mock_pull_request: PullRequest,
     mock_github_repo: MagicMock,
     monkeypatch,
+    charm_id: str,
+    charm_dir: str,
 ):
     """
     arrange: given running discourse server
@@ -55,7 +58,7 @@ async def test_run_migrate(
         4. no operation are done
     """
     caplog.set_level(logging.INFO)
-    document_name = "migration name 1"
+    document_name = f"migration name {charm_id}"
     discourse_prefix = discourse_address
     content_page_1 = factories.ContentPageFactory()
     content_page_1_url = discourse_api.create_topic(
@@ -102,14 +105,20 @@ Testing index page content.
         content=index_page_content,
     )
 
-    repository_client = RepositoryClient(Repo(repository_path), mock_github_repo)
+    charm_path = repository_path / charm_dir
+    # exist_ok=True as it can be the base directory
+    charm_path.mkdir(exist_ok=True)
+
+    repository_client = RepositoryClient(
+        Repo(repository_path), mock_github_repo, charm_dir=charm_dir
+    )
 
     # 1. with no docs dir and a metadata.yaml with docs key
     caplog.clear()
 
     create_metadata_yaml(
         content=f"{metadata.METADATA_NAME_KEY}: name 1\n{metadata.METADATA_DOCS_KEY}: {index_url}",
-        path=repository_path,
+        path=charm_path,
     )
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
@@ -126,7 +135,7 @@ Testing index page content.
     )
 
     upstream_git_repo.git.checkout(DEFAULT_BRANCH_NAME)
-    upstream_doc_dir = upstream_repository_path / constants.DOCUMENTATION_FOLDER_NAME
+    upstream_doc_dir = upstream_repository_path / charm_dir / constants.DOCUMENTATION_FOLDER_NAME
     assert output_migrate is not None
     assert output_migrate.pull_request_url == mock_pull_request.html_url
     assert output_migrate.action == PullRequestAction.OPENED
@@ -173,7 +182,9 @@ Testing index page content.
     output_migrate = run_migrate(
         Clients(
             discourse=discourse_api,
-            repository=RepositoryClient(Repo(repository_path), mock_github_repo),
+            repository=RepositoryClient(
+                Repo(repository_path), mock_github_repo, charm_dir=charm_dir
+            ),
         ),
         user_inputs=factories.UserInputsFactory(commit_sha=repository_client.current_commit),
     )
@@ -193,7 +204,9 @@ Testing index page content.
     output_migrate = run_migrate(
         Clients(
             discourse=discourse_api,
-            repository=RepositoryClient(Repo(repository_path), mock_github_repo),
+            repository=RepositoryClient(
+                Repo(repository_path), mock_github_repo, charm_dir=charm_dir
+            ),
         ),
         user_inputs=factories.UserInputsFactory(commit_sha=repository_client.current_commit),
     )
@@ -237,7 +250,9 @@ Testing index page content.
     output_migrate = run_migrate(
         Clients(
             discourse=discourse_api,
-            repository=RepositoryClient(Repo(repository_path), mock_github_repo),
+            repository=RepositoryClient(
+                Repo(repository_path), mock_github_repo, charm_dir=charm_dir
+            ),
         ),
         user_inputs=factories.UserInputsFactory(commit_sha=repository_client.current_commit),
     )

--- a/tests/integration/test___init__run_reconcile.py
+++ b/tests/integration/test___init__run_reconcile.py
@@ -143,7 +143,8 @@ async def test_run(
     )
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
-        "3. docs with a documentation file added in dry run mode"
+        "3. docs with a documentation file added in dry run mode",
+        directory=repository_client.docs_path,
     )
 
     output_reconcile = run_reconcile(
@@ -190,7 +191,8 @@ async def test_run(
     mock_github_repo.get_contents.return_value = mock_content_file
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
-        "5. docs with a documentation file updated in dry run mode"
+        "5. docs with a documentation file updated in dry run mode",
+        directory=repository_client.docs_path,
     )
 
     output_reconcile = run_reconcile(
@@ -239,7 +241,9 @@ async def test_run(
     (nested_dir := docs_dir / nested_dir_table_key).mkdir()
     (nested_dir / ".gitkeep").touch()
 
-    repository_client.switch(DEFAULT_BRANCH).update_branch("7. docs with a nested directory added")
+    repository_client.switch(DEFAULT_BRANCH).update_branch(
+        "7. docs with a nested directory added", directory=repository_client.docs_path
+    )
 
     output_reconcile = run_reconcile(
         clients=Clients(discourse=discourse_api, repository=repository_client),
@@ -265,7 +269,8 @@ async def test_run(
     )
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
-        "8. docs with a documentation file added in the nested directory"
+        "8. docs with a documentation file added in the nested directory",
+        directory=repository_client.docs_path,
     )
 
     output_reconcile = run_reconcile(
@@ -308,7 +313,8 @@ async def test_run(
     )
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
-        "9. docs with index file with a local contents index"
+        "9. docs with index file with a local contents index",
+        directory=repository_client.docs_path,
     )
 
     output_reconcile = run_reconcile(
@@ -353,7 +359,8 @@ async def test_run(
     nested_dir_doc_file.unlink()
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
-        "10. docs with the documentation file in the nested directory removed in dry run mode"
+        "10. docs with the documentation file in the nested directory removed in dry run mode",
+        directory=repository_client.docs_path,
     )
 
     output_reconcile = run_reconcile(
@@ -402,7 +409,9 @@ async def test_run(
     caplog.clear()
     shutil.rmtree(nested_dir)
 
-    repository_client.switch(DEFAULT_BRANCH).update_branch("12. with the nested directory removed")
+    repository_client.switch(DEFAULT_BRANCH).update_branch(
+        "12. with the nested directory removed", directory=repository_client.docs_path
+    )
 
     output_reconcile = run_reconcile(
         clients=Clients(discourse=discourse_api, repository=repository_client),
@@ -426,7 +435,7 @@ async def test_run(
     doc_file.unlink()
 
     repository_client.switch(DEFAULT_BRANCH).update_branch(
-        "13. with the documentation file removed"
+        "13. with the documentation file removed", directory=repository_client.docs_path
     )
 
     output_reconcile = run_reconcile(
@@ -452,7 +461,9 @@ async def test_run(
     caplog.clear()
     index_file.unlink()
 
-    repository_client.switch(DEFAULT_BRANCH).update_branch("14. with the index file removed")
+    repository_client.switch(DEFAULT_BRANCH).update_branch(
+        "14. with the index file removed", directory=repository_client.docs_path
+    )
 
     output_reconcile = run_reconcile(
         clients=Clients(discourse=discourse_api, repository=repository_client),

--- a/tests/integration/test___init__run_reconcile.py
+++ b/tests/integration/test___init__run_reconcile.py
@@ -30,13 +30,7 @@ pytestmark = pytest.mark.reconcile
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("git_repo")
-@pytest.mark.parametrize(
-    "charm_id, charm_dir",
-    [
-        ("1", ""),
-        ("2", "charm"),
-    ],
-)
+@pytest.mark.parametrize("charm_id, charm_dir", [("1", ""), ("2", "charm")])
 async def test_run(
     discourse_api: Discourse,
     caplog: pytest.LogCaptureFixture,

--- a/tests/integration/test___init__run_reconcile.py
+++ b/tests/integration/test___init__run_reconcile.py
@@ -29,6 +29,7 @@ pytestmark = pytest.mark.reconcile
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("git_repo")
 @pytest.mark.parametrize(
     "charm_id, charm_dir",
     [

--- a/tests/integration/test_discourse.py
+++ b/tests/integration/test_discourse.py
@@ -327,6 +327,6 @@ async def test_read_write_permission(
     assert alternate_user_discourse.check_topic_read_permission(
         url=url
     ), "alternate user could not read topic another user created"
-    assert (
-        alternate_user_discourse.check_topic_write_permission(url=url) is False
+    assert not alternate_user_discourse.check_topic_write_permission(
+        url=url
     ), "user could write topic another user created"

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -22,6 +22,18 @@ def create_metadata_yaml(content: str, path: Path) -> None:
     metadata_yaml.write_text(content, encoding="utf-8")
 
 
+def create_charmcraft_yaml(content: str, path: Path) -> None:
+    """Create the charmcraft file.
+
+    Args:
+        content: The text to be written to the file.
+        path: The directory to create the file in.
+
+    """
+    charmcraft_yaml = path / metadata.CHARMCRAFT_FILENAME
+    charmcraft_yaml.write_text(content, encoding="utf-8")
+
+
 def assert_substrings_in_string(substrings: typing.Iterable[str], string: str) -> None:
     """Assert that a string contains substrings.
 

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -35,8 +35,9 @@ from .helpers import assert_substrings_in_string, create_metadata_yaml
 # pylint: disable=protected-access
 
 
+@pytest.mark.parametrize("charm_dir", ["", "charm"])
 @mock.patch("github.Github.get_repo")
-def test_setup_clients(get_repo_mock, git_repo_with_remote):
+def test_setup_clients(get_repo_mock, git_repo_with_remote, charm_dir):
     """
     arrange: given a local path and user_inputs
     act: when get_clients is called
@@ -46,10 +47,12 @@ def test_setup_clients(get_repo_mock, git_repo_with_remote):
 
     path = Path(git_repo_with_remote.working_dir)
 
-    user_inputs = factories.UserInputsFactory()
+    user_inputs = factories.UserInputsFactory(charm_dir=charm_dir)
     clients = get_clients(user_inputs=user_inputs, base_path=path)
 
     assert clients.repository.base_path == path
+    assert clients.repository.base_charm_path == path / charm_dir
+    assert clients.repository.docs_path == path / charm_dir / DOCUMENTATION_FOLDER_NAME
 
     assert clients.discourse._category_id == int(user_inputs.discourse.category_id)
     assert clients.discourse.host == f"https://{user_inputs.discourse.hostname}"

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -11,7 +11,6 @@ from git.repo import Repo
 from github.PullRequest import PullRequest
 
 from src import (  # GETTING_STARTED,
-    DOCUMENTATION_FOLDER_NAME,
     DOCUMENTATION_TAG,
     Clients,
     constants,
@@ -23,7 +22,7 @@ from src import (  # GETTING_STARTED,
     types_,
 )
 from src.clients import get_clients
-from src.constants import DEFAULT_BRANCH
+from src.constants import DEFAULT_BRANCH, DOCUMENTATION_FOLDER_NAME
 from src.metadata import METADATA_DOCS_KEY, METADATA_NAME_KEY
 from src.repository import DEFAULT_BRANCH_NAME
 from src.repository import Client as RepositoryClient

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -142,7 +142,7 @@ def test__run_reconcile_local_empty_server(mocked_clients):
         (docs_folder := repo.base_path / "docs").mkdir()
         (docs_folder / "index.md").write_text(index_content := "index content\n")
         (docs_folder / "page.md").write_text(page_content := "page content")
-        repo.update_branch("new commit")
+        repo.update_branch("new commit", directory=repo.docs_path)
 
         user_inputs = factories.UserInputsFactory(
             dry_run=False, delete_pages=True, commit_sha=repo.current_commit
@@ -308,7 +308,7 @@ def test__run_reconcile_local_contents_index(mocked_clients):
 """,
             encoding="utf-8",
         )
-        repo.update_branch("new commit")
+        repo.update_branch("new commit", directory=repo.docs_path)
 
         user_inputs = factories.UserInputsFactory(
             dry_run=False, delete_pages=True, commit_sha=repo.current_commit
@@ -363,7 +363,7 @@ def test__run_reconcile_hidden_item(mocked_clients):
 """,
             encoding="utf-8",
         )
-        repo.update_branch("new commit")
+        repo.update_branch("new commit", directory=repo.docs_path)
 
         user_inputs = factories.UserInputsFactory(
             dry_run=False, delete_pages=True, commit_sha=repo.current_commit
@@ -408,7 +408,7 @@ def test__run_reconcile_invalid_external_item(mocked_clients):
 """,
             encoding="utf-8",
         )
-        repo.update_branch("new commit")
+        repo.update_branch("new commit", directory=repo.docs_path)
 
         user_inputs = factories.UserInputsFactory(
             dry_run=False, delete_pages=True, commit_sha=repo.current_commit
@@ -443,7 +443,7 @@ def test__run_reconcile_external_item(mocked_clients):
 """,
             encoding="utf-8",
         )
-        repo.update_branch("new commit")
+        repo.update_branch("new commit", directory=repo.docs_path)
 
         user_inputs = factories.UserInputsFactory(
             dry_run=False, delete_pages=True, commit_sha=repo.current_commit
@@ -624,7 +624,9 @@ def test__run_reconcile_on_tag_commit(caplog, mocked_clients):
     (docs_folder / "index.md").write_text("index content")
     (docs_folder / "page.md").write_text("page content 2")
 
-    repository_client.switch(DEFAULT_BRANCH).update_branch("First commit of documentation")
+    repository_client.switch(DEFAULT_BRANCH).update_branch(
+        "First commit of documentation", directory=repository_client.docs_path
+    )
 
     repository_client.tag_commit(DOCUMENTATION_TAG, repository_client.current_commit)
     user_inputs = factories.UserInputsFactory(commit_sha=repository_client.current_commit)

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from src import DOCUMENTATION_FOLDER_NAME, DOCUMENTATION_TAG, constants
+from src import DOCUMENTATION_TAG, constants
 from src.download import recreate_docs
 from src.metadata import METADATA_DOCS_KEY, METADATA_NAME_KEY
 
@@ -40,9 +40,14 @@ def test_recreate_docs(
 
     recreate_docs(mocked_clients, DOCUMENTATION_TAG)
 
-    assert (index_file := repository_path / DOCUMENTATION_FOLDER_NAME / "index.md").is_file()
     assert (
-        path_file := repository_path / DOCUMENTATION_FOLDER_NAME / "page-path-1" / "page-file-1.md"
+        index_file := repository_path / constants.DOCUMENTATION_FOLDER_NAME / "index.md"
+    ).is_file()
+    assert (
+        path_file := repository_path
+        / constants.DOCUMENTATION_FOLDER_NAME
+        / "page-path-1"
+        / "page-file-1.md"
     ).is_file()
     assert index_file.read_text(encoding="utf-8") == (
         f"{index_content}\n"

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -23,7 +23,7 @@ def test__read_docs_index_docs_directory_missing(tmp_path: Path):
     act: when _read_docs_index is called with the directory
     assert: then None is returned.
     """
-    returned_content = index._read_docs_index(base_path=tmp_path)
+    returned_content = index._read_docs_index(docs_path=tmp_path)
 
     assert returned_content is None
 
@@ -37,7 +37,7 @@ def test__read_docs_index_index_file_missing(tmp_path: Path):
     docs_directory = tmp_path / constants.DOCUMENTATION_FOLDER_NAME
     docs_directory.mkdir()
 
-    returned_content = index._read_docs_index(base_path=tmp_path)
+    returned_content = index._read_docs_index(docs_path=docs_directory)
 
     assert returned_content is None
 
@@ -48,7 +48,8 @@ def test__read_docs_index_index_file(index_file_content: str, tmp_path: Path):
     act: when _read_docs_index is called with the directory
     assert: then the index file content is returned.
     """
-    returned_content = index._read_docs_index(base_path=tmp_path)
+    docs_directory = tmp_path / constants.DOCUMENTATION_FOLDER_NAME
+    returned_content = index._read_docs_index(docs_path=docs_directory)
 
     assert returned_content == index_file_content
 
@@ -63,9 +64,10 @@ def test_get_metadata_yaml_retrieve_discourse_error(tmp_path: Path):
     meta = types_.Metadata(name="name", docs="http://server/index-page")
     mocked_server_client = mock.MagicMock(spec=discourse.Discourse)
     mocked_server_client.retrieve_topic.side_effect = DiscourseError
+    docs_directory = tmp_path / constants.DOCUMENTATION_FOLDER_NAME
 
     with pytest.raises(ServerError) as exc_info:
-        index.get(metadata=meta, base_path=tmp_path, server_client=mocked_server_client)
+        index.get(metadata=meta, docs_path=docs_directory, server_client=mocked_server_client)
 
     assert_substrings_in_string(("index page", "retrieval", "failed"), str(exc_info.value).lower())
 
@@ -83,9 +85,10 @@ def test_get_metadata_yaml_retrieve_local_and_server(tmp_path: Path, index_file_
     meta = types_.Metadata(name=name, docs=url)
     mocked_server_client = mock.MagicMock(spec=discourse.Discourse)
     mocked_server_client.retrieve_topic.return_value = (content := "content 2")
+    docs_directory = tmp_path / constants.DOCUMENTATION_FOLDER_NAME
 
     returned_index = index.get(
-        metadata=meta, base_path=tmp_path, server_client=mocked_server_client
+        metadata=meta, docs_path=docs_directory, server_client=mocked_server_client
     )
 
     assert returned_index.server is not None
@@ -106,9 +109,10 @@ def test_get_metadata_yaml_retrieve_empty(tmp_path: Path):
     name = "name 1"
     meta = types_.Metadata(name=name, docs=None)
     mocked_server_client = mock.MagicMock(spec=discourse.Discourse)
+    docs_directory = tmp_path / constants.DOCUMENTATION_FOLDER_NAME
 
     returned_index = index.get(
-        metadata=meta, base_path=tmp_path, server_client=mocked_server_client
+        metadata=meta, docs_path=docs_directory, server_client=mocked_server_client
     )
 
     assert returned_index.server is None

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -88,24 +88,32 @@ def test_get_invalid_metadata(
     assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())
 
 
-# pylint currently does not understand walrus operator perfectly yet
-# pylint: disable=unused-variable,undefined-variable
-@pytest.mark.parametrize(
-    "metadata_yaml_content, expected_metadata",
-    [
+def _get_metadata_parameters():
+    """Generate parameters for the metadata_parameters test.
+
+    Returns:
+        The test parameters, the first item of each element is the metadata content,
+        the second the expected types_.Metadata and the third the test id.
+    """
+    name = "name"
+    docs = "https://discourse.charmhub.io/t/index/1"
+    return [
         pytest.param(
-            f"{metadata.METADATA_NAME_KEY}: {(name := 'name')}",
+            f"{metadata.METADATA_NAME_KEY}: {name}",
             types_.Metadata(name=name, docs=None),
             id="name only",
         ),
         pytest.param(
-            f"{metadata.METADATA_NAME_KEY}: {name}\n"
-            f"{metadata.METADATA_DOCS_KEY}: "
-            f"{(docs := 'https://discourse.charmhub.io/t/index/1')}",
+            f"{metadata.METADATA_NAME_KEY}: {name}\n" f"{metadata.METADATA_DOCS_KEY}: " f"{docs}",
             types_.Metadata(name=name, docs=docs),
             id="name and docs",
         ),
-    ],
+    ]
+
+
+@pytest.mark.parametrize(
+    "metadata_yaml_content, expected_metadata",
+    _get_metadata_parameters(),
 )
 def test_get_metadata(
     metadata_yaml_content: str,
@@ -193,13 +201,18 @@ def test_get_invalid_charmcraft(
     assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())
 
 
-# pylint currently does not understand walrus operator perfectly yet
-# pylint: disable=unused-variable,undefined-variable
-@pytest.mark.parametrize(
-    "charmcraft_yaml_content, expected_metadata",
-    [
+def _get_charmcraft_parameters():
+    """Generate parameters for the get_charmcraft test.
+
+    Returns:
+        The test parameters, the first item of each element is the charmcraft content,
+        the second the expected types_.Metadata and the third the test id.
+    """
+    name = "name"
+    docs = "https://discourse.charmhub.io/t/index/1"
+    return [
         pytest.param(
-            f"{metadata.CHARMCRAFT_NAME_KEY}: {(name := 'name')}",
+            f"{metadata.CHARMCRAFT_NAME_KEY}: {name}",
             types_.Metadata(name=name, docs=None),
             id="name only",
         ),
@@ -207,11 +220,15 @@ def test_get_invalid_charmcraft(
             f"{metadata.CHARMCRAFT_NAME_KEY}: {name}\n"
             f"{metadata.CHARMCRAFT_LINKS_KEY}:\n"
             f"  {metadata.CHARMCRAFT_LINKS_DOCS_KEY}: "
-            f"{(docs := 'https://discourse.charmhub.io/t/index/1')}",
+            f"{docs}",
             types_.Metadata(name=name, docs=docs),
             id="name and docs",
         ),
-    ],
+    ]
+
+
+@pytest.mark.parametrize(
+    "charmcraft_yaml_content, expected_metadata", _get_charmcraft_parameters()
 )
 def test_get_charmcraft(
     charmcraft_yaml_content: str,

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -9,7 +9,7 @@ import pytest
 
 from src import exceptions, metadata, types_
 
-from .helpers import assert_substrings_in_string, create_metadata_yaml
+from .helpers import assert_substrings_in_string, create_charmcraft_yaml, create_metadata_yaml
 
 
 def test_get_yaml_missing(tmp_path: Path):
@@ -22,6 +22,7 @@ def test_get_yaml_missing(tmp_path: Path):
         metadata.get(path=tmp_path)
 
     assert metadata.METADATA_FILENAME in str(exc_info.value).lower()
+    assert metadata.CHARMCRAFT_FILENAME in str(exc_info.value).lower()
 
 
 @pytest.mark.parametrize(
@@ -34,7 +35,7 @@ def test_get_yaml_missing(tmp_path: Path):
         pytest.param("value 1", ("not", "mapping", metadata.METADATA_FILENAME), id="not dict"),
     ],
 )
-def test_get_yaml_malformed(
+def test_get_metadata_yaml_malformed(
     metadata_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
 ):
     """
@@ -106,7 +107,7 @@ def test_get_invalid_metadata(
         ),
     ],
 )
-def test_get(
+def test_get_metadata(
     metadata_yaml_content: str,
     expected_metadata: types_.Metadata,
     tmp_path: Path,
@@ -118,6 +119,112 @@ def test_get(
     """
     create_metadata_yaml(
         content=metadata_yaml_content,
+        path=tmp_path,
+    )
+
+    data = metadata.get(path=tmp_path)
+
+    assert data == expected_metadata
+
+
+@pytest.mark.parametrize(
+    "charmcraft_yaml_content, expected_error_msg_contents",
+    [
+        pytest.param("", ("empty", metadata.CHARMCRAFT_FILENAME), id="malformed"),
+        pytest.param(
+            "malformed: yaml:", ("malformed", metadata.CHARMCRAFT_FILENAME), id="malformed"
+        ),
+        pytest.param("value 1", ("not", "mapping", metadata.CHARMCRAFT_FILENAME), id="not dict"),
+    ],
+)
+def test_get_charmcraft_yaml_malformed(
+    charmcraft_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
+):
+    """
+    arrange: given directory with charmcraft.yaml that is malformed
+    act: when get is called with the directory
+    assert: then InputError is raised.
+    """
+    create_charmcraft_yaml(content=charmcraft_yaml_content, path=tmp_path)
+
+    with pytest.raises(exceptions.InputError) as exc_info:
+        metadata.get(path=tmp_path)
+
+    assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())
+
+
+@pytest.mark.parametrize(
+    "charmcraft_yaml_content, expected_error_msg_contents",
+    [
+        pytest.param("key: value", ("could not find", metadata.CHARMCRAFT_NAME_KEY)),
+        pytest.param(
+            f"{metadata.CHARMCRAFT_NAME_KEY}: 1",
+            (
+                "invalid value for",
+                metadata.CHARMCRAFT_NAME_KEY,
+            ),
+        ),
+        pytest.param(
+            f"{metadata.CHARMCRAFT_NAME_KEY}: name\n{metadata.CHARMCRAFT_LINKS_KEY}: 1",
+            ("invalid value for", metadata.CHARMCRAFT_LINKS_KEY),
+        ),
+        pytest.param(
+            (
+                f"{metadata.CHARMCRAFT_NAME_KEY}: name\n"
+                f"{metadata.CHARMCRAFT_LINKS_KEY}:\n {metadata.CHARMCRAFT_LINKS_DOCS_KEY}: 1"
+            ),
+            ("invalid value for", metadata.CHARMCRAFT_LINKS_DOCS_KEY),
+        ),
+    ],
+)
+def test_get_invalid_charmcraft(
+    charmcraft_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
+):
+    """
+    arrange: given charmcraft with missing required keys or invalid value
+    act: when get is called with the directory
+    assert: InputError is raised with missing keys info.
+    """
+    create_charmcraft_yaml(content=charmcraft_yaml_content, path=tmp_path)
+
+    with pytest.raises(exceptions.InputError) as exc_info:
+        metadata.get(path=tmp_path)
+
+    assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())
+
+
+# pylint currently does not understand walrus operator perfectly yet
+# pylint: disable=unused-variable,undefined-variable
+@pytest.mark.parametrize(
+    "charmcraft_yaml_content, expected_metadata",
+    [
+        pytest.param(
+            f"{metadata.CHARMCRAFT_NAME_KEY}: {(name := 'name')}",
+            types_.Metadata(name=name, docs=None),
+            id="name only",
+        ),
+        pytest.param(
+            f"{metadata.CHARMCRAFT_NAME_KEY}: {name}\n"
+            f"{metadata.CHARMCRAFT_LINKS_KEY}:\n"
+            f"  {metadata.CHARMCRAFT_LINKS_DOCS_KEY}: "
+            f"{(docs := 'https://discourse.charmhub.io/t/index/1')}",
+            types_.Metadata(name=name, docs=docs),
+            id="name and docs",
+        ),
+    ],
+)
+def test_get_charmcraft(
+    charmcraft_yaml_content: str,
+    expected_metadata: types_.Metadata,
+    tmp_path: Path,
+):
+    """
+    arrange: given directory with metadata.yaml with valid metadata yaml
+    act: when get is called with the directory
+    assert: then file contents are returned as a dictionary.
+    """
+    create_charmcraft_yaml(
+        content=charmcraft_yaml_content,
         path=tmp_path,
     )
 

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -144,7 +144,7 @@ def test_commit_in_branch_check(repository_client, docs_path):
         test_branch
     ) as repo:
         (docs_path / "placeholder.md").touch()
-        repo.update_branch("commit of placeholder")
+        repo.update_branch("commit of placeholder", directory=repository_client.docs_path)
         assert repo.is_commit_in_branch(repo.current_commit)
         assert repo.is_commit_in_branch(repo.current_commit, test_branch)
         assert not repo.is_commit_in_branch(repo.current_commit, DEFAULT_BRANCH)
@@ -233,7 +233,7 @@ def test_create_branch(
 
     repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
         branch_name
-    ).update_branch(commit_msg="commit-1", push=True)
+    ).update_branch(commit_msg="commit-1", push=True, directory=repository_client.docs_path)
 
     # mypy false positive in lib due to getter/setter not being next to each other.
     assert any(
@@ -268,7 +268,7 @@ def test_create_branch_checkout_clash_default(
 
     repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
         branch_name
-    ).update_branch(commit_msg="commit-1", push=True)
+    ).update_branch(directory=repository_client.docs_path, commit_msg="commit-1", push=True)
 
     assert upstream_git_repo.git.ls_tree("-r", branch_name, "--name-only")
 
@@ -291,7 +291,7 @@ def test_create_branch_checkout_clash_created(
 
     repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
         branch_name
-    ).update_branch(commit_msg="commit-1", push=True)
+    ).update_branch(directory=repository_client.docs_path, commit_msg="commit-1", push=True)
 
     assert upstream_git_repo.git.ls_tree("-r", branch_name, "--name-only")
 
@@ -377,7 +377,9 @@ def test_tag_commit_tag_update(repository_client: Client, upstream_git_repo, doc
 
     (docs_path / "placeholder.md").touch()
 
-    repository_client.switch(DEFAULT_BRANCH).update_branch("my new commit")
+    repository_client.switch(DEFAULT_BRANCH).update_branch(
+        "my new commit", directory=repository_client.docs_path
+    )
 
     repository_client.tag_commit(DOCUMENTATION_TAG, repository_client.current_commit)
 
@@ -408,7 +410,7 @@ def test_tag_other_commit(repository_client: Client, docs_path: Path):
 
         (docs_path / "placeholder.md").touch()
 
-        repo.update_branch("my new commit")
+        repo.update_branch("my new commit", directory=repository_client.docs_path)
 
         new_hash = repo.current_commit
 
@@ -853,7 +855,7 @@ def test_commit_file_outside_of_folder(repository_client, upstream_git_repo, doc
     assert (Path(upstream_git_repo.working_dir) / directory / file2).exists()
 
     # Locally the repository is dirty only when directory is set to None
-    assert not repository_client.get_summary().is_dirty
+    assert not repository_client.get_summary(directory=directory).is_dirty
     assert repository_client.get_summary(directory=None).is_dirty
 
 
@@ -881,7 +883,7 @@ def test_repository_pull_default_branch(
 
     (docs_path / "filler-file-1").touch()
 
-    repository_client.update_branch("commit 1")
+    repository_client.update_branch("commit 1", directory=repository_client.docs_path)
 
     upstream_git_repo.git.checkout(branch_name)
     first_hash = upstream_git_repo.head.ref.commit.hexsha
@@ -909,7 +911,7 @@ def test_repository_pull_other_branch(
 
     (docs_path / "filler-file-1").touch()
 
-    repository_client.update_branch("commit 1")
+    repository_client.update_branch("commit 1", directory=repository_client.docs_path)
 
     upstream_git_repo.git.checkout(branch_name)
     first_hash = upstream_git_repo.head.ref.commit.hexsha
@@ -1045,7 +1047,7 @@ def test_update_branch_unknown_error(monkeypatch, repository_client: Client):
     monkeypatch.setattr(repository_client._git_repo, "is_dirty", lambda *_args, **_kwargs: True)
 
     with pytest.raises(RepositoryClientError) as exc:
-        repository_client.update_branch("my-message")
+        repository_client.update_branch("my-message", directory=repository_client.docs_path)
 
     assert_substrings_in_string(("unexpected error updating branch"), str(exc.value).lower())
 
@@ -1068,7 +1070,7 @@ def test_update_branch_github_api_git_error(monkeypatch, repository_client: Clie
     monkeypatch.setattr(repository_client._git_repo, "is_dirty", lambda *_args, **_kwargs: True)
 
     with pytest.raises(RepositoryClientError) as exc:
-        repository_client.update_branch("my-message")
+        repository_client.update_branch("my-message", directory=repository_client.docs_path)
 
     assert_substrings_in_string(("unexpected error updating branch"), str(exc.value).lower())
 
@@ -1099,7 +1101,7 @@ def test_update_branch_github_api_github_error(
     monkeypatch.setattr(repository_client._git_repo, "is_dirty", lambda *_args, **_kwargs: True)
 
     with pytest.raises(RepositoryClientError) as exc:
-        repository_client.update_branch("my-message")
+        repository_client.update_branch("my-message", directory=repository_client.docs_path)
 
     assert_substrings_in_string(("unexpected error updating branch"), str(exc.value).lower())
 
@@ -1132,7 +1134,7 @@ def test_update_branch_github_api(
     monkeypatch.setattr(repository_client._git_repo, "git", mock_git_repository)
     monkeypatch.setattr(repository_client._git_repo, "is_dirty", lambda *_args, **_kwargs: True)
 
-    repository_client.update_branch("my-message")
+    repository_client.update_branch("my-message", directory=repository_client.docs_path)
 
     # Check that the branch.edit was called, more detailed checks are in
     # test__github_client_push_single

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -711,6 +711,33 @@ def test_create_repository_client(
     assert isinstance(returned_client, repository.Client)
 
 
+def test_create_repository_client_with_charm_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    git_repo_with_remote: Repo,
+    repository_path: Path,
+    mock_github_repo: Repository,
+):
+    """
+    arrange: given valid repository path and a valid access_token and a mocked github client
+       with a customised charm_dir
+    act: when create_repository_client is called
+    assert: RepositoryClient is returned with correct charm paths and docs paths
+    """
+    _ = git_repo_with_remote
+
+    test_token = secrets.token_hex(16)
+    mock_github_client = mock.MagicMock(spec=Github)
+    mock_github_client.get_repo.returns = mock_github_repo
+    monkeypatch.setattr(repository, "Github", mock_github_client)
+
+    returned_client = repository.create_repository_client(
+        access_token=test_token, base_path=repository_path, charm_dir="charm"
+    )
+
+    assert returned_client.base_charm_path == returned_client.base_path / "charm"
+    assert returned_client.docs_path == returned_client.base_charm_path / DOCUMENTATION_FOLDER_NAME
+
+
 @pytest.mark.parametrize(
     "folder",
     [


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

These are the requirements for PAAS app charmer with respect to discourse-gatekeeper:
 - Use charmcraft.yaml as there is no metadata.yaml. 
 - Use a custom directory instead of the root directory for the charm. Also, the docs will be inside the charm directory.

Currently, the name and the link to the documentation are just read from the `metadata.yaml` file. However, the new recommended way is to set in the `charmcraft.yaml` file (see https://juju.is/docs/sdk/charmcraft-yaml). This PR reads those fields from `charmcraft.yaml` if `metadata.yaml` does not exist. This PR does not take into account the case where name is one file and the link to the doc is in the other file. In that case, the suggestion could be to put both fields in the same file (preferably charmcraft.yaml).

Besides there is a new input variable, charm_dir, thats allows to customise the place where the metadata/charmcraft file is placed and where the docs directory is.

It was necessary to delete the `rate_limit_new_user_create_topic`, as it does not exist anymore in discourse (before that, it was not used in discourse anyway).

### Rationale

<!-- The reason the change is needed -->
It was not possible to use this project for PAAS app charmer autogenerated projects, as they use the `charmcraft.yaml` file and the charm directory is not in the root of the repository.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Changelog has been updated
- [x] Version has been incremented

<!-- Explanation for any unchecked items above -->
