### PR TITLE
Extend hierarchy calculation for deeply nested pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,7 @@
 
 - Project prepared to be installed with `pip install`, so it can be reused in 
   the repository https://github.com/canonical/gatekeeper-repo-test
-
-## [v0.9.1] - 2024-06-28
-
-### Fixed
-
-- Support for navigation table with hierarchy jumps of more than 1 level
+- Added support for navigation table with hierarchy jumps of more than 1 level
 
 ## [v0.9.0] - 2024-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Project prepared to be installed with `pip install`, so it can be reused in 
   the repository https://github.com/canonical/gatekeeper-repo-test
 
+## [v0.9.1] - 2024-06-28
+
+### Fixed
+
+- Support for navigation table with hierarchy jumps of more than 1 level
+
 ## [v0.9.0] - 2024-04-04
 
 ### Added

--- a/src-docs/index.py.md
+++ b/src-docs/index.py.md
@@ -123,7 +123,7 @@ Classify the type of a reference.
 
 ---
 
-<a href="../src/gatekeeper/index.py#L413"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/gatekeeper/index.py#L414"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_contents`
 

--- a/src/gatekeeper/index.py
+++ b/src/gatekeeper/index.py
@@ -370,6 +370,7 @@ def _calculate_contents_hierarchy(
             hierarchy = hierarchy - 1
             parent = parents.pop()
             aggregate_dir = Path(parent.reference_value).parent
+            continue
 
         _check_contents_item(
             item=item,

--- a/tests/unit/test_index_contents_hierarchy.py
+++ b/tests/unit/test_index_contents_hierarchy.py
@@ -266,6 +266,50 @@ def _test__calculate_contents_hierarchy_invalid_parameters():
             ("not immediately within", "directory", value_1, repr(item)),
             id="directory in wrong directory",
         ),
+        pytest.param(
+            (
+                item_1 := factories.IndexParsedListItemFactory(
+                    whitespace_count=0, reference_value=(value_1 := "dir1")
+                ),
+                item_2 := factories.IndexParsedListItemFactory(
+                    whitespace_count=1, reference_value=(value_2 := f"{value_1}/dir2")
+                ),
+                item_3 := factories.IndexParsedListItemFactory(
+                    whitespace_count=2, reference_value=(value_3 := f"{value_2}/file3.md")
+                ),
+                item_4 := factories.IndexParsedListItemFactory(
+                    whitespace_count=0, reference_value=(value_4 := "dir4")
+                ),   
+            ),
+            ("dir", "dir", "file", "dir"),
+            (
+                factories.IndexContentsListItemFactory(
+                    hierarchy=1,
+                    reference_title=item_1.reference_title,
+                    reference_value=value_1,
+                    rank=item_1.rank,
+                ),
+                factories.IndexContentsListItemFactory(
+                    hierarchy=2,
+                    reference_title=item_2.reference_title,
+                    reference_value=value_2,
+                    rank=item_2.rank,
+                ),
+                factories.IndexContentsListItemFactory(
+                    hierarchy=3,
+                    reference_title=item_3.reference_title,
+                    reference_value=value_3,
+                    rank=item_3.rank,
+                ),
+                factories.IndexContentsListItemFactory(
+                    hierarchy=1,
+                    reference_title=item_4.reference_title,
+                    reference_value=value_4,
+                    rank=item_4.rank,
+                ),
+            ),
+            id="dir following an item nested more than once",
+        )
     ]
 
 


### PR DESCRIPTION
### Overview

A small change to the calculation of page hierarchy to account for navigation tables with large jumps in nesting. 

Previously, the difference in whitespace only got evaluated once, which only accounts for cases where the next item is nested one level higher or lower - but not more.

### Rationale

This change is needed because the action fails on documentation sets with hierarchy jumps greater than 1. More context + examples in issue #249.   

### Module Changes

None

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Changelog has been updated
- [ ] Version has been incremented

