### PR TITLE
Upgrade git to the version available for this distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM python:3.12-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git=1:2.39.* && \
+    apt-get install -y --no-install-recommends git=1:2.47.* && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /usr/src/app


### PR DESCRIPTION
The base python:3.12-slim image has been upgraded so the pinned version of Git is not found anymore. This PR uses the version available in this base image.