### PR TITLE
Fix integration test by pinning the discourse version

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -56,7 +56,9 @@ async def discourse(model: Model) -> Application:
         apps=[postgres_charm_name, redis_charm_name], status="active", raise_on_error=False
     )
 
-    discourse_app: Application = await model.deploy(discourse_charm_name, channel="edge")
+    discourse_app: Application = await model.deploy(
+        discourse_charm_name, channel="edge", revision=144
+    )
     await model.wait_for_idle(apps=[discourse_charm_name], status="waiting", raise_on_error=False)
 
     await model.integrate(discourse_charm_name, f"{postgres_charm_name}:database")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -57,7 +57,7 @@ async def discourse(model: Model) -> Application:
     )
 
     discourse_app: Application = await model.deploy(
-        discourse_charm_name, channel="edge", revision=144
+        discourse_charm_name, channel="edge", revision=206
     )
     await model.wait_for_idle(apps=[discourse_charm_name], status="waiting", raise_on_error=False)
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] Changelog has been updated
- [x] Version has been incremented

<!-- Explanation for any unchecked items above -->
